### PR TITLE
tsconfig target es5로 수정 및 recruit과 동기화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ yarn-error.log*
 
 .stylelintcache
 .eslintcache
+
+# TS
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.tsx",
   "scripts": {
     "start": "webpack serve --config ./webpack/webpack.dev.js",
-    "build-dev": "webpack --config ./webpack/webpack.dev.js",
-    "build-prod": "webpack --config ./webpack/webpack.prod.js",
-    "type-check": "tsc src/*.(ts|tsx) --noEmit",
+    "build-dev": "yarn type-check && webpack --config ./webpack/webpack.dev.js",
+    "build-prod": "yarn type-check && webpack --config ./webpack/webpack.prod.js",
+    "type-check": "tsc --build ./tsconfig.json",
     "test": "jest --watchAll --coverage",
     "test:ci": "jest",
     "lint:code": "eslint --ext .js,.jsx,.ts,.tsx src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react",
     "incremental": true,
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "typeRoots": ["./@types/*"],
     "types": ["jest", "node"]
   },
-  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./@types", "**/*.config.js"]
+  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./@types"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,26 @@
 {
   "compilerOptions": {
-    "jsx": "react",
-    "module": "commonjs",
-    "esModuleInterop": true,
-    "target": "es2021",
-    "moduleResolution": "node",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "strict": true,
-    "rootDir": "./",
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"],
-    },
     "skipLibCheck": true,
-    "typeRoots": ["./node_modules/@types", "./@types/*"],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "rootDir": ".",
+    "typeRoots": ["./@types/*"],
     "types": ["jest", "node"]
   },
-  "exclude": ["./node_modules", "./dist"],
-  "include": ["./src", "./@types", "**/*.config.js"]
+  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./@types", "**/*.config.js"]
 }


### PR DESCRIPTION
## 변경사항
지난 번 admin 회의에서 브라우저 지원을 위해 ts-loader를 사용할 경우 target을 es5로 낮추자는 의견을 반영했습니다.

하는김에 recruit tsconfig과 sync를 맞추었고 type-check와  build script를 적절하게 수정했습니다.

* forceConsistentCasingInFileNames 추가
* ~~module esnext로 변경~~ // 빌드 에러 발생
* target es5로 변경
* lib 추가("dom", "dom.iterable", "esnext")
* noEmit 추가(true)
* isolatedModules 추가(true)
* ~~jsx preserve로 변경~~ // jest 에러 발생
* incremental 추가(true)
* exclude 제거
* outDir 제거
* 빌드시 타입체크 활성화
* tsconfig.tsbuildinfo gitignore에 추가

### 작업 유형

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)