### PR TITLE
pathname에 따라 배경 색을 white, gray10 으로 각각 토글되도록 처리

### DIFF
--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -6,7 +6,10 @@ import * as Styled from './Layout.styled';
 const Layout = () => {
   const { pathname } = useLocation();
 
-  const isBackgroundGray = useMemo(() => ['/login'].some((each) => each === pathname), [pathname]);
+  const isBackgroundGray = useMemo(
+    () => ['login', 'application/', 'application-form/'].some((each) => pathname.includes(each)),
+    [pathname],
+  );
 
   return (
     <>

--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -1,14 +1,20 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useMemo } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { Header } from '@/components';
 import * as Styled from './Layout.styled';
 
 const Layout = () => {
+  const { pathname } = useLocation();
+
+  const isBackgroundGray = useMemo(() => ['/login'].some((each) => each === pathname), [pathname]);
+
   return (
     <>
       <Header />
-      <Styled.Main>
-        <Outlet />
+      <Styled.Main isBackgroundGray={isBackgroundGray}>
+        <section>
+          <Outlet />
+        </section>
       </Styled.Main>
     </>
   );

--- a/src/components/common/Layout/Layout.styled.ts
+++ b/src/components/common/Layout/Layout.styled.ts
@@ -8,7 +8,7 @@ interface StyledMainProps {
 
 export const Main = styled.main<StyledMainProps>`
   ${({ isBackgroundGray, theme }) => css`
-    background-color: ${isBackgroundGray ? theme.colors.gray30 : theme.colors.white};
+    background-color: ${isBackgroundGray ? theme.colors.gray10 : theme.colors.white};
 
     & > section {
       max-width: 120rem;

--- a/src/components/common/Layout/Layout.styled.ts
+++ b/src/components/common/Layout/Layout.styled.ts
@@ -1,8 +1,19 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { HEADER_HEIGHT } from '@/constants';
 
-export const Main = styled.main`
-  max-width: 120rem;
-  min-height: calc(100vh - ${HEADER_HEIGHT});
-  margin: 0 auto;
+interface StyledMainProps {
+  isBackgroundGray: boolean;
+}
+
+export const Main = styled.main<StyledMainProps>`
+  ${({ isBackgroundGray, theme }) => css`
+    background-color: ${isBackgroundGray ? theme.colors.gray30 : theme.colors.white};
+
+    & > section {
+      max-width: 120rem;
+      min-height: calc(100vh - ${HEADER_HEIGHT});
+      margin: 0 auto;
+    }
+  `}
 `;


### PR DESCRIPTION
## 변경사항

main 에 width를 고정하면 배경색이 width 기준으로 적용되어서 하위  section 계층을 하나 더 추가하였습니다.

아래 기준에 맞춰서 'login', 'application/', 'application-form/' 이 pathname에 포함되면 isBackgroundGray 로 배경 색을 선택하도록 처리했습니다.
- 로그인
    - /login - gray10
- 지원서 내역
    - /application - white
- 지원서 상세
    - /application/:id - gray10
- SMS 발송 내역
    - /sms - white 
- 지원 설문지 내역
    - /application-form - white
- 지원 설문지 상세
    - 상세
        - /application-form/:id - gray10
    - 추가
        - /application-form/create - gray10
    - 수정
        - /application-form/update/:id - gray10
- not found
    - /404 - 미정
 
### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정
- 문서 업데이트
- 배포 관련
- 프로젝트 설정(웹팩, 바벨, 린팅 등)
- 패키지 추가 및 버전 변경

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)