### PR TITLE
지원서 설문지 상세페이지 가지지 않는 버그 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // import React, { ReactNode, Suspense } from 'react';
 import React, { Suspense } from 'react';
 // import { Routes, Route, Navigate, NavigateProps } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 
 import { Global, ThemeProvider } from '@emotion/react';
 // import { useRecoilValue, useRecoilCallback } from 'recoil';

--- a/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
+++ b/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { useRecoilCallback, useRecoilState } from 'recoil';
 import { useParams } from 'react-router-dom';
+import { FormProvider, useForm } from 'react-hook-form';
 import { ApplicationFormSection, ApplicationFormAside } from '@/components';
 import * as Styled from './ApplicationFormDetail.styled';
 
-import { ParamId, QuestionKind } from '@/types';
+import { ParamId, Question, QuestionKind } from '@/types';
 
 import { $applicationFormDetail } from '@/store/applicationForm';
 import { InputSize } from '@/components/common/Input/Input.component';
 import * as api from '@/api';
+
+interface FormValues {
+  questions: Question[];
+}
 
 const ApplicationFormDetail = () => {
   const { id } = useParams<ParamId>();
@@ -16,6 +21,8 @@ const ApplicationFormDetail = () => {
   const [{ questions, name, team, createdAt, createdBy, updatedAt, updatedBy }] = useRecoilState(
     $applicationFormDetail({ id: id ?? '' }),
   );
+
+  const methods = useForm<FormValues>({ defaultValues: { questions } });
 
   const handleRemoveQuestion = useRecoilCallback(() => async () => {
     if (!id) {
@@ -27,55 +34,57 @@ const ApplicationFormDetail = () => {
   });
 
   return (
-    <Styled.ApplicationFormDetailPage>
-      <ApplicationFormSection headline="지원서 설문지 상세" />
-      <div>
-        <article>
-          <Styled.Content>
-            <span>지원설문지 문서명</span>
-            <span>{name}</span>
-          </Styled.Content>
-          <Styled.QuestionContent>
-            {questions.map((question, index) => {
-              const readableIndex = index + 1;
+    <FormProvider {...methods}>
+      <Styled.ApplicationFormDetailPage>
+        <ApplicationFormSection headline="지원서 설문지 상세" />
+        <div>
+          <article>
+            <Styled.Content>
+              <span>지원설문지 문서명</span>
+              <span>{name}</span>
+            </Styled.Content>
+            <Styled.QuestionContent>
+              {questions.map((question, index) => {
+                const readableIndex = index + 1;
 
-              const props = {
-                label: `${readableIndex}. ${question.content}`,
-                description: question.description,
-                disabled: true,
-                required: question.required,
-              };
+                const props = {
+                  label: `${readableIndex}. ${question.content}`,
+                  description: question.description,
+                  disabled: true,
+                  required: question.required,
+                };
 
-              return (
-                <li key={question.questionId}>
-                  {question.questionType === QuestionKind.multiLineText ? (
-                    <Styled.CustomTextarea {...props} placeholder="장문형 텍스트입니다." />
-                  ) : (
-                    <Styled.CustomInput
-                      {...props}
-                      $size={InputSize.md}
-                      placeholder="단답형 텍스트입니다."
-                    />
-                  )}
-                </li>
-              );
-            })}
-          </Styled.QuestionContent>
-        </article>
-        <ApplicationFormAside
-          platform={team.name}
-          createdAt={createdAt}
-          createdBy={createdBy}
-          updatedAt={updatedAt}
-          updatedBy={updatedBy}
-          leftActionButton={{
-            text: '삭제',
-            onClick: handleRemoveQuestion,
-          }}
-          rightActionButton={{ text: '수정' }}
-        />
-      </div>
-    </Styled.ApplicationFormDetailPage>
+                return (
+                  <li key={question.questionId}>
+                    {question.questionType === QuestionKind.multiLineText ? (
+                      <Styled.CustomTextarea {...props} placeholder="장문형 텍스트입니다." />
+                    ) : (
+                      <Styled.CustomInput
+                        {...props}
+                        $size={InputSize.md}
+                        placeholder="단답형 텍스트입니다."
+                      />
+                    )}
+                  </li>
+                );
+              })}
+            </Styled.QuestionContent>
+          </article>
+          <ApplicationFormAside
+            platform={team.name}
+            createdAt={createdAt}
+            createdBy={createdBy}
+            updatedAt={updatedAt}
+            updatedBy={updatedBy}
+            leftActionButton={{
+              text: '삭제',
+              onClick: handleRemoveQuestion,
+            }}
+            rightActionButton={{ text: '수정' }}
+          />
+        </div>
+      </Styled.ApplicationFormDetailPage>
+    </FormProvider>
   );
 };
 


### PR DESCRIPTION
## 변경사항

- 지원서 설문지 상세페이지 가지지 않는 버그 수정
  - 상위 요소에 Form이 없는데 Form에서 값을 가져와서 ApplicationFormPreview에서 오류가 나고 있었음.
- App.tsx 안쓰는 값 있어서 커밋이 안돼서 수정 

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)