### PR TITLE
AlertModalDialog에 핸들러를 넣고 새로고침시 유지 안되도록 처리

### DIFF
--- a/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.component.tsx
@@ -1,25 +1,9 @@
-import React, { MutableRefObject } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { MouseEventHandler, MutableRefObject } from 'react';
 import { useRecoilState } from 'recoil';
 import { ModalWrapper } from '@/components';
 import * as Styled from './AlertModalDialog.styled';
 import { $modalByStorage, ModalKey } from '@/store';
 import { Position } from '@/components/common/ModalWrapper/ModalWrapper.component';
-
-export const SMS_COMPLETE = {
-  heading: 'SMS 발송 완료',
-  paragraph: 'SMS 발송내역 페이지로 이동하시겠습니까?',
-  cancelButtonLabel: '취소',
-  confirmButtonLabel: '이동',
-  linkTo: 'sms',
-};
-
-export const POPUP_CLOSE = {
-  heading: '팝업을 닫으시겠습니까?',
-  paragraph: '변경 또는 작성하신 데이터가 삭제됩니다.',
-  cancelButtonLabel: '취소',
-  confirmButtonLabel: '닫기',
-};
 
 export interface AlertModalDialogProps {
   heading: string;
@@ -28,6 +12,7 @@ export interface AlertModalDialogProps {
   confirmButtonLabel?: string;
   linkTo?: string;
   beforeRef?: MutableRefObject<HTMLButtonElement>;
+  handleClickConfirmButton?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const AlertModalDialog = ({
@@ -35,9 +20,8 @@ const AlertModalDialog = ({
   paragraph,
   cancelButtonLabel = '취소',
   confirmButtonLabel = '확인',
-  linkTo,
+  handleClickConfirmButton,
 }: AlertModalDialogProps) => {
-  const navigate = useNavigate();
   const [modal, setModal] = useRecoilState($modalByStorage(ModalKey.alertModalDialog));
 
   const handleRemoveCurrentModal = () => setModal({ ...modal, isOpen: false });
@@ -49,11 +33,11 @@ const AlertModalDialog = ({
       },
       confirmButton: {
         label: confirmButtonLabel,
-        onClick: linkTo ? () => navigate(linkTo) : () => handleRemoveCurrentModal(),
+        onClick: handleClickConfirmButton || handleRemoveCurrentModal,
       },
       position: Position.center,
     },
-    handleCloseModal: () => handleRemoveCurrentModal(),
+    handleCloseModal: handleRemoveCurrentModal,
   };
 
   return (

--- a/src/components/common/AlertModalDialog/AlertModalDialog.stories.tsx
+++ b/src/components/common/AlertModalDialog/AlertModalDialog.stories.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import AlertModalDialog, {
-  AlertModalDialogProps,
-  SMS_COMPLETE,
-  POPUP_CLOSE,
-} from './AlertModalDialog.component';
+import AlertModalDialog, { AlertModalDialogProps } from './AlertModalDialog.component';
 
 export default {
   title: 'AlertModalDialog',
@@ -15,7 +11,37 @@ const Template: ComponentStory<typeof AlertModalDialog> = (args: AlertModalDialo
 };
 
 export const SmsComplete = Template.bind({});
-SmsComplete.args = SMS_COMPLETE;
+SmsComplete.args = {
+  heading: 'SMS 발송 완료',
+  paragraph: 'SMS 발송내역 페이지로 이동하시겠습니까?',
+  cancelButtonLabel: '취소',
+  confirmButtonLabel: '이동',
+  handleClickConfirmButton: () => {},
+};
 
 export const PopupClose = Template.bind({});
-PopupClose.args = POPUP_CLOSE;
+PopupClose.args = {
+  heading: '팝업을 닫으시겠습니까?',
+  paragraph: '변경 또는 작성하신 데이터가 삭제됩니다.',
+  cancelButtonLabel: '취소',
+  confirmButtonLabel: '닫기',
+  handleClickConfirmButton: () => {},
+};
+
+export const isDelete = Template.bind({});
+isDelete.args = {
+  heading: '삭제하시겠습니까?',
+  paragraph: '작성 또는 수정하신 데이터가 삭제됩니다.',
+  cancelButtonLabel: '취소',
+  confirmButtonLabel: '닫기',
+  handleClickConfirmButton: () => {},
+};
+
+export const isSave = Template.bind({});
+isDelete.args = {
+  heading: '저장하시겠습니까?',
+  paragraph: '지원서 설문지 내역에서 확인하실 수 있습니다.',
+  cancelButtonLabel: '취소',
+  confirmButtonLabel: '저장',
+  handleClickConfirmButton: () => {},
+};

--- a/src/components/common/ModalViewer/ModalViewer.component.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.component.tsx
@@ -1,18 +1,13 @@
-import React from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { $modalByStorage, ModalKey, ModalKeyType } from '@/store';
 import { AlertModalDialog } from '@/components';
 
 const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
-  const [modal] = useRecoilState($modalByStorage(modalKey));
-  const { hash } = window.location;
+  const modal = useRecoilValue($modalByStorage(modalKey));
+  // const { hash } = window.location;
 
-  if (
-    modalKey === ModalKey.alertModalDialog &&
-    modal.isOpen &&
-    modal.props &&
-    hash.split('#').some((each) => each === ModalKey.alertModalDialog)
-  ) {
+  if (modalKey === ModalKey.alertModalDialog && modal.isOpen && modal.props) {
     return <AlertModalDialog key={modalKey} {...modal.props} />;
   }
 
@@ -20,6 +15,13 @@ const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
 };
 
 const ModalViewer = () => {
+  const setModal = useSetRecoilState($modalByStorage(ModalKey.alertModalDialog));
+
+  // TODO:(용재) 추후 더 나은 방법 찾아보기..
+  useEffect(() => {
+    setModal({ key: ModalKey.alertModalDialog, isOpen: false });
+  }, [setModal]);
+
   return (
     <>
       {Object.values(ModalKey).map((each) => {

--- a/src/components/common/ModalViewer/ModalViewer.stories.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.stories.tsx
@@ -4,10 +4,6 @@ import { useRecoilState } from 'recoil';
 import ModalViewer from './ModalViewer.component';
 import { Button } from '@/components';
 import { $modalByStorage, ModalKey } from '@/store';
-import {
-  POPUP_CLOSE,
-  SMS_COMPLETE,
-} from '@/components/common/AlertModalDialog/AlertModalDialog.component';
 
 export default {
   title: 'Modal Viewer',
@@ -21,7 +17,13 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
         onClick={() =>
           setModal({
             ...modal,
-            props: SMS_COMPLETE,
+            props: {
+              heading: 'SMS 발송 완료',
+              paragraph: 'SMS 발송내역 페이지로 이동하시겠습니까?',
+              cancelButtonLabel: '취소',
+              confirmButtonLabel: '이동',
+              handleClickConfirmButton: () => {},
+            },
             isOpen: true,
           })
         }
@@ -32,12 +34,52 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
         onClick={() =>
           setModal({
             ...modal,
-            props: POPUP_CLOSE,
+            props: {
+              heading: '팝업을 닫으시겠습니까?',
+              paragraph: '변경 또는 작성하신 데이터가 삭제됩니다.',
+              cancelButtonLabel: '취소',
+              confirmButtonLabel: '닫기',
+              handleClickConfirmButton: () => {},
+            },
             isOpen: true,
           })
         }
       >
         팝업 닫기 알럿모달
+      </Button>
+      <Button
+        onClick={() =>
+          setModal({
+            ...modal,
+            props: {
+              heading: '삭제하시겠습니까?',
+              paragraph: '작성 또는 수정하신 데이터가 삭제됩니다.',
+              cancelButtonLabel: '취소',
+              confirmButtonLabel: '닫기',
+              handleClickConfirmButton: () => {},
+            },
+            isOpen: true,
+          })
+        }
+      >
+        삭제하기 모달
+      </Button>
+      <Button
+        onClick={() =>
+          setModal({
+            ...modal,
+            props: {
+              heading: '저장하시겠습니까?',
+              paragraph: '지원서 설문지 내역에서 확인하실 수 있습니다.',
+              cancelButtonLabel: '취소',
+              confirmButtonLabel: '저장',
+              handleClickConfirmButton: () => {},
+            },
+            isOpen: true,
+          })
+        }
+      >
+        저장하기 모달
       </Button>
       <ModalViewer />
     </div>

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -35,6 +35,9 @@ export const $modalByStorage = selectorFamily<Modal, ModalKeyType>({
     (key) =>
     ({ get }) => {
       const hash = Object.values(ModalKey).reduce<string>((acc, cur) => {
+        if (cur === ModalKey.alertModalDialog) {
+          return acc;
+        }
         const curVal = get($modal(cur));
         return curVal.isOpen ? `${acc}#${curVal.key}` : acc;
       }, '');


### PR DESCRIPTION
## 변경사항

- ModalViewer 스토리를 참고해서 사용하시면 됩니다.
- 새로고침시 AlertModalDialog는 유지되지 않도록 처리했습니다
- confirm button 클릭시 handler를 props로 넣을 수 있도록 처리했습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)