### PR TITLE
MASHUP_SUBLEADER 처럼 SUBLEADER에 공백을 제거한다

### DIFF
--- a/src/components/common/UserProfile/UserProfile.component.tsx
+++ b/src/components/common/UserProfile/UserProfile.component.tsx
@@ -17,7 +17,7 @@ export const Team = {
 // TODO:(@mango906): 추후 서버에서 내려주는 값에 따라 value값 변경 필요
 export const Role = {
   leader: 'LEADER',
-  subLeader: 'SUB LEADER',
+  subLeader: 'SUBLEADER',
   member: 'MEMBER',
 } as const;
 

--- a/src/styles/themes/userProfile.ts
+++ b/src/styles/themes/userProfile.ts
@@ -3,7 +3,7 @@ import { colors } from '.';
 
 const Role = {
   leader: 'LEADER',
-  subLeader: 'SUB LEADER',
+  subLeader: 'SUBLEADER',
   member: 'MEMBER',
 } as const;
 


### PR DESCRIPTION
## 변경사항

- UserProfile 컴포넌트 내부 Role 객체 내부 값 중 SUBLEADER 에 공백이 있는 이슈가 있어서 이를 처리했습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)