### PR TITLE
QA 1차 대응 (v0.0.1) - minsour

### DIFF
--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -1,18 +1,27 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import { Input } from '@/components';
 import { ButtonSize, ButtonShape } from '@/components/common/Button/Button.component';
 import * as Styled from './SearchOptionBar.styled';
 
 interface SearchOptionBarProps {
+  searchWord: { value: string };
   handleSubmit: React.FormEventHandler<HTMLFormElement>;
 }
 
-const SearchOptionBar = ({ handleSubmit }: SearchOptionBarProps) => {
+const SearchOptionBar = ({ searchWord, handleSubmit }: SearchOptionBarProps) => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.value = searchWord.value;
+    }
+  }, [searchWord]);
+
   return (
     <Styled.BarContainer onSubmit={handleSubmit}>
       <div />
       <Styled.SearchInputContainer>
-        <Input name="searchWord" $size="xs" placeholder="지원서 설문지 문서명 검색" />
+        <Input ref={ref} name="searchWord" $size="xs" placeholder="지원서 설문지 문서명 검색" />
         <Styled.SearchButton type="submit" $size={ButtonSize.xs} shape={ButtonShape.default}>
           검색
         </Styled.SearchButton>

--- a/src/components/common/Table/Table.component.tsx
+++ b/src/components/common/Table/Table.component.tsx
@@ -18,9 +18,10 @@ import Checkbox from '../Checkbox/Checkbox.component';
 export interface TableColumn<T extends object> {
   title: string;
   accessor?: NestedKeyOf<T>;
+  idAccessor?: NestedKeyOf<T>;
   widthRatio: string;
   sortable?: boolean;
-  renderCustomCell?: (cellVaule: unknown) => ReactNode;
+  renderCustomCell?: (cellVaule: unknown, id?: string) => ReactNode;
 }
 
 interface TableProps<T extends object> {
@@ -214,12 +215,13 @@ const Table = <T extends object>({
                         />
                       )}
                       {columns.map((column, columnIndex) => {
-                        const { accessor, renderCustomCell } = column;
+                        const { accessor, idAccessor, renderCustomCell } = column;
                         const cellValue = accessor ? getOwnValueByKey(row, accessor) : null;
+                        const id = idAccessor ? getOwnValueByKey(row, idAccessor) : null;
 
                         return (
                           <Styled.TableCell key={`cell-${columnIndex}`}>
-                            {renderCustomCell ? renderCustomCell(cellValue) : cellValue}
+                            {renderCustomCell ? renderCustomCell(cellValue, id) : cellValue}
                           </Styled.TableCell>
                         );
                       })}

--- a/src/components/common/Table/Table.component.tsx
+++ b/src/components/common/Table/Table.component.tsx
@@ -23,17 +23,11 @@ export interface TableColumn<T extends object> {
   renderCustomCell?: (cellVaule: unknown) => ReactNode;
 }
 
-export interface TableClickableRow<T extends object> {
-  accessor: NestedKeyOf<T>;
-  handleClickRow: (id: string) => void;
-}
-
 interface TableProps<T extends object> {
   prefix: string;
   maxHeight?: number;
   columns: TableColumn<T>[];
   rows: T[];
-  clickableRow?: TableClickableRow<T>;
   isLoading: boolean;
   sortType?: string[];
   sortColumn?: string[];
@@ -105,7 +99,6 @@ const Table = <T extends object>({
   columns,
   rows,
   isLoading,
-  clickableRow,
   selectableRow,
   supportBar: { totalCount, totalSummaryText, selectedSummaryText, buttons: supportButtons },
   pagination,
@@ -213,14 +206,7 @@ const Table = <T extends object>({
                 </colgroup>
                 <Styled.TableBody>
                   {rows.map((row, rowIndex) => (
-                    <Styled.TableRow
-                      key={`${prefix}-row-${rowIndex}`}
-                      height={DEFAULT_ROW_HEIGHT}
-                      clickable={!!clickableRow}
-                      onClick={() =>
-                        clickableRow?.handleClickRow(getOwnValueByKey(row, clickableRow.accessor))
-                      }
-                    >
+                    <Styled.TableRow key={`${prefix}-row-${rowIndex}`} height={DEFAULT_ROW_HEIGHT}>
                       {!!selectableRow && (
                         <RowCheckBox
                           isChecked={checkedValues.current[rowIndex]}

--- a/src/components/common/Table/Table.styled.ts
+++ b/src/components/common/Table/Table.styled.ts
@@ -67,21 +67,20 @@ export const TableHeader = styled.thead`
   `}
 `;
 
-export const TableBody = styled.tbody``;
-
-export const TableRow = styled.tr<{ height: number; clickable?: boolean }>`
-  ${({ theme, height, clickable }) => css`
-    height: ${height}rem;
-    border-bottom: ${theme.colors.gray20} solid 0.1rem;
-
-    ${clickable &&
-    css`
-      cursor: pointer;
-
+export const TableBody = styled.tbody`
+  ${({ theme }) => css`
+    & tr {
       &:hover {
         background-color: ${theme.colors.purple20};
       }
-    `};
+    }
+  `};
+`;
+
+export const TableRow = styled.tr<{ height: number }>`
+  ${({ theme, height }) => css`
+    height: ${height}rem;
+    border-bottom: ${theme.colors.gray20} solid 0.1rem;
   `}
 `;
 

--- a/src/components/common/Table/Table.styled.ts
+++ b/src/components/common/Table/Table.styled.ts
@@ -97,6 +97,7 @@ export const TableCell = styled.td`
   ${({ theme }) => css`
     ${theme.fonts.regular14}
 
+    height: 0;
     color: ${theme.colors.gray80};
     vertical-align: middle;
   `}

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -99,13 +99,13 @@ const ApplicationFormList = () => {
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
 
-  const [searchWord, setSearchWord] = useState('');
+  const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
   const applicationFormParams = useMemo<ApplicationFormRequest>(
     () => ({
       page: parseInt(page, 10) - 1,
       size: parseInt(size, 10),
       teamId: parseInt(teamId, 10) || undefined,
-      searchWord,
+      searchWord: searchWord.value,
     }),
     [page, size, teamId, searchWord],
   );
@@ -128,7 +128,7 @@ const ApplicationFormList = () => {
     e: { target: { searchWord: { value: string } } } & FormEvent<HTMLFormElement>,
   ) => {
     e.preventDefault();
-    setSearchWord(e.target.searchWord.value);
+    setSearchWord({ value: e.target.searchWord.value });
   };
 
   useEffect(() => {
@@ -140,13 +140,19 @@ const ApplicationFormList = () => {
   useEffect(() => {
     refreshApplicationForms();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, size, teamId, searchWord]);
+  }, [page, size, searchWord]);
+
+  useEffect(() => {
+    refreshApplicationForms();
+    setSearchWord({ value: '' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamId]);
 
   return (
     <Styled.PageWrapper>
       <Styled.Heading>지원서 설문지 내역</Styled.Heading>
       <TeamNavigationTabs />
-      <SearchOptionBar handleSubmit={handleSubmit} />
+      <SearchOptionBar searchWord={searchWord} handleSubmit={handleSubmit} />
       <Table<ApplicationFormResponse>
         prefix="application"
         columns={columns}

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -52,7 +52,7 @@ const columns: TableColumn<ApplicationFormResponse>[] = [
     idAccessor: 'applicationFormId',
     widthRatio: '28%',
     renderCustomCell: (cellValue, id) => (
-      <Styled.FormTitleWrapper>
+      <Styled.FormTitleWrapper title={cellValue as string}>
         <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
         <Styled.TitleLink to={`${PATH.APPLICATION_FORM}/${id}`} />
       </Styled.FormTitleWrapper>

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useRecoilStateLoadable, useRecoilValue, useRecoilRefresher_UNSTABLE } from 'recoil';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import Preview from '@/assets/svg/preview-20.svg';
 
@@ -49,8 +49,14 @@ const columns: TableColumn<ApplicationFormResponse>[] = [
   {
     title: '지원서 설문지 문서명',
     accessor: 'name',
+    idAccessor: 'applicationFormId',
     widthRatio: '28%',
-    renderCustomCell: (cellValue) => <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>,
+    renderCustomCell: (cellValue, id) => (
+      <Styled.FormTitleWrapper>
+        <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
+        <Styled.TitleLink to={`${PATH.APPLICATION_FORM}/${id}`} />
+      </Styled.FormTitleWrapper>
+    ),
   },
   {
     title: '작성자',
@@ -86,7 +92,6 @@ const columns: TableColumn<ApplicationFormResponse>[] = [
 ];
 
 const ApplicationFormList = () => {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
@@ -158,12 +163,6 @@ const ApplicationFormList = () => {
               </Button>
             </Link>,
           ],
-        }}
-        clickableRow={{
-          accessor: 'applicationFormId',
-          handleClickRow: (id) => {
-            navigate(`${PATH.APPLICATION_FORM}/${id}`);
-          },
         }}
         pagination={
           <Pagination

--- a/src/pages/ApplicationFormList/ApplicationFormList.styled.ts
+++ b/src/pages/ApplicationFormList/ApplicationFormList.styled.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { Link } from '@/components';
 
 export const PageWrapper = styled.div`
   padding: 4rem 0;
@@ -15,13 +16,36 @@ export const Heading = styled.h2`
   `};
 `;
 
+export const FormTitleWrapper = styled.div`
+  ${({ theme }) => css`
+    position: relative;
+
+    &:hover {
+      color: ${theme.colors.purple90};
+      font-weight: 500;
+      text-decoration: underline;
+      text-underline-position: under;
+    }
+  `};
+`;
+
 export const FormTitle = styled.div`
-  width: 100%;
-  padding: 0 1rem;
-  overflow: hidden;
-  white-space: nowrap;
-  text-align: left;
-  text-overflow: ellipsis;
+  ${({ theme }) => css`
+    width: 100%;
+    height: 100%;
+    padding: 0 1rem;
+    overflow: hidden;
+    color: ${theme.colors.purple80};
+    line-height: 5.2rem;
+    white-space: nowrap;
+    text-align: left;
+    text-overflow: ellipsis;
+  `};
+`;
+
+export const TitleLink = styled(Link)`
+  position: absolute;
+  inset: 0;
 `;
 
 export const CustomUserProfile = styled.div`
@@ -36,4 +60,5 @@ export const Center = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 100%;
 `;

--- a/src/styles/themes/colors.ts
+++ b/src/styles/themes/colors.ts
@@ -10,6 +10,7 @@ export const colors = {
   gray70: '#495057',
   gray80: '#343A40',
   gray90: '#212529',
+  purple90: '#140087',
   purple80: '#4127D1',
   purple70: '#6244FF',
   purple60: '#836BFF',


### PR DESCRIPTION
## 변경사항

- 지원서 설문지 내역 페이지 내 테이블에서 미리보기 아이콘 버튼 클릭 시 미리보기가 뜨지 않고 상세 페이지로 넘어가는 이슈 해결
  - tr 태그 내부에 미리보기 icon을 포함하는 button이 위치하고 tr과 button 두 요소에 onClick이 걸려있는 상황이었음
  button이 클릭되었을 때 tr의 onClick 함수가 실행되는 이슈라서 button onClick에서 stopPropagation()으로 이벤트 버블링의 전파를 막아주려고 하였지만, React에서 stopPropagation이 제대로 동작하지 않는 이슈가 있어 결국 스펙을 변경함
  
  as-is
  tr 태그(테이블의 로우)를 클릭하면 상세 페이지로 이동함
  : tr, button 두 요소에 이벤트 바인딩
  
  to-be
  테이블의 문서명 셀을 클릭해야 상세 페이지로 이동함
  : button 에만 이벤트 바인딩
  
- 지원서 설문지 내역 페이지에서 팀 탭 이동 시 searchWord 초기화되도록 수정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)