### PR TITLE
QA 2차 대응 (v0.0.1) - mango906

### DIFF
--- a/src/components/ApplicationForm/ApplicationFormTemplate/ApplicationFormTemplate.component.tsx
+++ b/src/components/ApplicationForm/ApplicationFormTemplate/ApplicationFormTemplate.component.tsx
@@ -13,7 +13,11 @@ interface FormValues {
 }
 
 const DEFAULT_QUESTION: Partial<Question> = {
+  content: '',
+  description: '',
+  maxContentLength: null,
   questionType: QuestionKind.multiLineText,
+  required: false,
 };
 
 const ApplicationFormTemplate = () => {
@@ -41,12 +45,7 @@ const ApplicationFormTemplate = () => {
       </Styled.Content>
       <Styled.QuestionContent>
         {fields.map((field, index) => (
-          <ApplicationFormItem
-            {...field}
-            key={field.id}
-            index={index}
-            handleRemoveItem={handleRemoveItem}
-          />
+          <ApplicationFormItem key={field.id} index={index} handleRemoveItem={handleRemoveItem} />
         ))}
         <Styled.Divider />
         <Styled.AddButton type="button" onClick={() => append(DEFAULT_QUESTION)}>

--- a/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
+++ b/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
@@ -58,11 +58,13 @@ const ApplicationFormDetail = () => {
                 message: '성공적으로 지원서 설문지를 삭제했습니다.',
               });
 
+              navigate(PATH.APPLICATION_FORM);
+            },
+            onCompleted: () => {
               set($modalByStorage(ModalKey.alertModalDialog), {
                 ...modalSnapshot,
                 isOpen: false,
               });
-              navigate(PATH.APPLICATION_FORM);
             },
           });
         },

--- a/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
+++ b/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
@@ -23,7 +23,11 @@ interface FormValues {
 }
 
 const DEFAULT_QUESTION: Partial<Question> = {
+  content: '',
+  description: '',
+  maxContentLength: null,
   questionType: QuestionKind.multiLineText,
+  required: false,
 };
 
 const current = new Date().toISOString();

--- a/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
+++ b/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { ApplicationFormAside, ApplicationFormSection } from '@/components';
 import * as Styled from './CreateApplicationForm.styled';
@@ -37,7 +37,7 @@ const CreateApplicationForm = () => {
     },
   });
 
-  const modal = useRecoilValue($modalByStorage(ModalKey.alertModalDialog));
+  const [modal, setModal] = useRecoilState($modalByStorage(ModalKey.alertModalDialog));
 
   const { register, handleSubmit, setValue, formState } = methods;
 
@@ -91,6 +91,12 @@ const CreateApplicationForm = () => {
               });
 
               navigate(getApplicationFormDetailPage(applicationFormId));
+            },
+            onCompleted: () => {
+              setModal({
+                ...modal,
+                isOpen: false,
+              });
             },
           });
         },

--- a/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
+++ b/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRecoilCallback, useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
+import { useRecoilCallback, useRecoilState, useResetRecoilState } from 'recoil';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FormProvider, useForm, useFormState } from 'react-hook-form';
 import * as Styled from './UpdateApplicationForm.styled';
@@ -25,7 +25,7 @@ const UpdateApplicationForm = () => {
     $applicationFormDetail({ id: id ?? '' }),
   );
 
-  const modal = useRecoilValue($modalByStorage(ModalKey.alertModalDialog));
+  const [modal, setModal] = useRecoilState($modalByStorage(ModalKey.alertModalDialog));
 
   const resetApplicationFormDetail = useResetRecoilState($applicationFormDetail({ id: id ?? '' }));
 
@@ -82,6 +82,12 @@ const UpdateApplicationForm = () => {
               });
 
               navigate(getApplicationFormDetailPage(id));
+            },
+            onCompleted: () => {
+              setModal({
+                ...modal,
+                isOpen: false,
+              });
             },
           });
         },

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -5,9 +5,15 @@ interface Request<T> {
   requestFunc: () => Promise<T>;
   errorHandler: (toast: ToastProps) => void;
   onSuccess?: (data: T) => void;
+  onCompleted?: () => void;
 }
 
-export const request = async <T>({ requestFunc, errorHandler, onSuccess }: Request<T>) => {
+export const request = async <T>({
+  requestFunc,
+  errorHandler,
+  onSuccess,
+  onCompleted,
+}: Request<T>) => {
   try {
     onSuccess?.(await requestFunc());
   } catch (error) {
@@ -21,5 +27,7 @@ export const request = async <T>({ requestFunc, errorHandler, onSuccess }: Reque
         }
       }
     }
+  } finally {
+    onCompleted?.();
   }
 };


### PR DESCRIPTION
## 변경사항

- 요청 중 에러날 경우 모달 닫히지 않는 버그 수정
  - onCompleted 추가해서 무조건 실행되도록 추가
- 설문 질문 지우고 다시 만들 경우 default values가 지워지지 않는 버그 수정
  - 설문지 수정에서 서버에서 온 값 지우고 다시 질문 추가할 경우 빈 질문이 생성되어야 하는데 서버에서 만들어진 값이 부활하는 버그
  - https://www.notion.so/de90ddd67ffb47e8aafc974d838f52c7?v=7132180c27804b5f8531f247b5bda56c&p=cbfe8819c05f44bbbd5aa3355a440d41 요 버그와도 관련됐는진 모르겠지만 실제 배포되고 확인해봐야할거 같음 (로컬에선 재현이 안됨 ㅠ 실제환경에서만 재현이 되네요)

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)