### PR TITLE
글자수 제한 수정했을 때 지원서 폼 저장되지 않는 이슈 수정

### DIFF
--- a/src/components/ApplicationForm/ApplicationFormItem/ApplicationFormItem.component.tsx
+++ b/src/components/ApplicationForm/ApplicationFormItem/ApplicationFormItem.component.tsx
@@ -106,8 +106,7 @@ const ApplicationFormItem = ({ index, handleRemoveItem }: ApplicationFormItemPro
                 type="number"
                 {...register(`questions.${index}.maxContentLength`, {
                   required: true,
-                  pattern: /[^0-9]/,
-                  min: 0,
+                  min: 1,
                 })}
               />
             )}


### PR DESCRIPTION
## 변경사항

- 글자수 제한 수정했을 때 지원서 폼 저장되지 않는 이슈 수정
  - 추적해보니 pattern 에러였고 - 못넣게 하려고 넣은 코드였는데 min으로 예외처리 가능해서 뻄

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)