### PR TITLE
SearchOptionBar에 합격여부, 사용자 확인여부 Select가 동작되도록 추가

### DIFF
--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -1,14 +1,66 @@
-import React, { useLayoutEffect, useRef } from 'react';
-import { Input } from '@/components';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Input, Select } from '@/components';
 import { ButtonSize, ButtonShape } from '@/components/common/Button/Button.component';
 import * as Styled from './SearchOptionBar.styled';
+import { SelectOption, SelectSize } from '../Select/Select.component';
+import {
+  ApplicationConfirmationStatus,
+  ApplicationConfirmationStatusKeyType,
+  ApplicationResultStatus,
+  ApplicationResultStatusKeyType,
+} from '../ApplicationStatusBadge/ApplicationStatusBadge.component';
 
 interface SearchOptionBarProps {
   searchWord: { value: string };
   handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  handleChangeApplicationConfirmationStatus?: (option: SelectOption) => void;
+  handleChangeApplicationResultStatus?: (option: SelectOption) => void;
 }
 
-const SearchOptionBar = ({ searchWord, handleSubmit }: SearchOptionBarProps) => {
+const DEFAULT = { label: '전체', value: 'DEFAULT' };
+
+const SearchOptionBar = ({
+  searchWord,
+  handleSubmit,
+  handleChangeApplicationConfirmationStatus,
+  handleChangeApplicationResultStatus,
+}: SearchOptionBarProps) => {
+  const [currentParam, setCurrentParam] = useState('');
+  const [searchParams] = useSearchParams();
+  const [applicationConfirmationStatusValue, setApplicationConfirmationStatusValue] =
+    useState<SelectOption>();
+  const [applicationResultStatusValue, setApplicationResultStatusValue] = useState<SelectOption>();
+
+  const handleApplicationConfirmStatus = (option: SelectOption) => {
+    setApplicationConfirmationStatusValue(option);
+  };
+
+  const handleApplicationResultStatus = (option: SelectOption) => {
+    setApplicationResultStatusValue(option);
+  };
+
+  useEffect(() => {
+    if (currentParam !== searchParams.get('team')) {
+      handleApplicationConfirmStatus(DEFAULT);
+      handleApplicationResultStatus(DEFAULT);
+
+      setCurrentParam(searchParams.get('team') || '');
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (applicationConfirmationStatusValue && handleChangeApplicationConfirmationStatus) {
+      handleChangeApplicationConfirmationStatus(applicationConfirmationStatusValue);
+    }
+  }, [applicationConfirmationStatusValue]);
+
+  useEffect(() => {
+    if (applicationResultStatusValue && handleChangeApplicationResultStatus) {
+      handleChangeApplicationResultStatus(applicationResultStatusValue);
+    }
+  }, [applicationResultStatusValue]);
+
   const ref = useRef<HTMLInputElement>(null);
 
   useLayoutEffect(() => {
@@ -17,8 +69,65 @@ const SearchOptionBar = ({ searchWord, handleSubmit }: SearchOptionBarProps) => 
     }
   }, [searchWord]);
 
+  const applicationConfirmationStatusOptions = useMemo(
+    () => [
+      DEFAULT,
+      ...Object.keys(ApplicationConfirmationStatus).reduce<SelectOption[]>(
+        (acc, cur) => [
+          ...acc,
+          {
+            label: ApplicationConfirmationStatus[cur as ApplicationConfirmationStatusKeyType],
+            value: cur,
+          },
+        ],
+        [],
+      ),
+    ],
+    [],
+  );
+
+  const applicationResultStatusOptions = useMemo(
+    () => [
+      DEFAULT,
+      ...Object.keys(ApplicationResultStatus).reduce<SelectOption[]>(
+        (acc, cur) => [
+          ...acc,
+          {
+            label: ApplicationResultStatus[cur as ApplicationResultStatusKeyType],
+            value: cur,
+          },
+        ],
+        [],
+      ),
+    ],
+    [],
+  );
+
   return (
     <Styled.BarContainer onSubmit={handleSubmit}>
+      <Styled.SelectContainer>
+        <div>
+          <div>합격여부</div>
+          <Select
+            size={SelectSize.xs}
+            options={applicationResultStatusOptions}
+            onChangeOption={handleApplicationConfirmStatus}
+            defaultValue={DEFAULT}
+            currentValue={applicationConfirmationStatusValue}
+          />
+        </div>
+        <div>
+          <div>사용자 확인여부</div>
+          <Select
+            size={SelectSize.xs}
+            options={applicationConfirmationStatusOptions}
+            onChangeOption={handleApplicationResultStatus}
+            defaultValue={DEFAULT}
+            currentValue={applicationResultStatusValue}
+          />
+        </div>
+      </Styled.SelectContainer>
+
       <div />
       <Styled.SearchInputContainer>
         <Input ref={ref} name="searchWord" $size="xs" placeholder="지원서 설문지 문서명 검색" />

--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -105,29 +105,30 @@ const SearchOptionBar = ({
 
   return (
     <Styled.BarContainer onSubmit={handleSubmit}>
-      <Styled.SelectContainer>
-        <div>
-          <div>합격여부</div>
-          <Select
-            size={SelectSize.xs}
-            options={applicationResultStatusOptions}
-            onChangeOption={handleApplicationConfirmStatus}
-            defaultValue={DEFAULT}
-            currentValue={applicationConfirmationStatusValue}
-          />
-        </div>
-        <div>
-          <div>사용자 확인여부</div>
-          <Select
-            size={SelectSize.xs}
-            options={applicationConfirmationStatusOptions}
-            onChangeOption={handleApplicationResultStatus}
-            defaultValue={DEFAULT}
-            currentValue={applicationResultStatusValue}
-          />
-        </div>
-      </Styled.SelectContainer>
-
+      {handleChangeApplicationConfirmationStatus && handleChangeApplicationResultStatus && (
+        <Styled.SelectContainer>
+          <div>
+            <div>합격여부</div>
+            <Select
+              size={SelectSize.xs}
+              options={applicationResultStatusOptions}
+              onChangeOption={handleApplicationConfirmStatus}
+              defaultValue={DEFAULT}
+              currentValue={applicationConfirmationStatusValue}
+            />
+          </div>
+          <div>
+            <div>사용자 확인여부</div>
+            <Select
+              size={SelectSize.xs}
+              options={applicationConfirmationStatusOptions}
+              onChangeOption={handleApplicationResultStatus}
+              defaultValue={DEFAULT}
+              currentValue={applicationResultStatusValue}
+            />
+          </div>
+        </Styled.SelectContainer>
+      )}
       <div />
       <Styled.SearchInputContainer>
         <Input ref={ref} name="searchWord" $size="xs" placeholder="지원서 설문지 문서명 검색" />

--- a/src/components/common/SearchOptionBar/SearchOptionBar.styled.ts
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.styled.ts
@@ -17,6 +17,25 @@ export const BarContainer = styled.form`
   `};
 `;
 
+export const SelectContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    gap: 3.6rem;
+
+    & > div {
+      ${theme.fonts.medium13}
+      display: flex;
+      gap: 1.2rem;
+      align-items: center;
+      color: ${theme.colors.gray70};
+
+      & span {
+        color: ${theme.colors.gray80};
+      }
+    }
+  `}
+`;
+
 export const SearchInputContainer = styled.div`
   display: flex;
   gap: 0.4rem;

--- a/src/components/common/Select/Select.component.tsx
+++ b/src/components/common/Select/Select.component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import * as Styled from './Select.styled';
 import ChevronDown from '@/assets/svg/chevron-down-16.svg';
 import { useOnClickOutSide } from '@/hooks';
@@ -31,6 +31,7 @@ export interface SelectProps {
   onChangeOption?: (option: SelectOption) => void;
   disabled?: boolean;
   defaultValue?: SelectOption;
+  currentValue?: SelectOption;
 }
 
 const Select = (
@@ -42,6 +43,7 @@ const Select = (
     options,
     isFullWidth = false,
     defaultValue,
+    currentValue,
     onChangeOption,
     disabled = false,
   }: SelectProps,
@@ -66,6 +68,12 @@ const Select = (
     toggleOpened();
     onChangeOption?.(option);
   };
+
+  useEffect(() => {
+    if (currentValue) {
+      setSelectedOption(currentValue);
+    }
+  }, [currentValue]);
 
   useOnClickOutSide(outerRef, () => setOpened(false));
 


### PR DESCRIPTION
## 변경사항

- 탭 바뀔 때 전체로 초기화 되도록 처리
- Select에 currentValue props를 추적하여 option이 변경될 수 있도록 처리
- 합격여부, 사용자 확인여부 handler를 통해 Select 값에 따라 콜백이 일어나도록 함
  * callback이 props로 넘어와야만 Select가 노출되도록 함

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)