### PR TITLE
발송인원 상세 리스트, SMS 발송 상세내역 모달 다이얼로그 베이스 추가

### DIFF
--- a/src/components/common/ModalViewer/ModalViewer.component.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.component.tsx
@@ -2,7 +2,12 @@ import React, { useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useLocation } from 'react-router-dom';
 import { $modalByStorage, ModalKey, ModalKeyType } from '@/store';
-import { AlertModalDialog, ChangeResultModalDialog, SmsSendModalDialog } from '@/components';
+import {
+  AlertModalDialog,
+  ChangeResultModalDialog,
+  SmsSendDetailListModalDialog,
+  SmsSendModalDialog,
+} from '@/components';
 import { AlertModalDialogProps } from '../AlertModalDialog/AlertModalDialog.component';
 import { ChangeResultModalDialogProps } from '@/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component';
 import { SmsSendModalDialogProps } from '../SmsSendModalDialog/SmsSendModalDialog.component';
@@ -24,6 +29,10 @@ const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
     return <SmsSendModalDialog key={modalKey} {...(modal.props as SmsSendModalDialogProps)} />;
   }
 
+  if (modalKey === ModalKey.smsSendDetailListModalDialog && modal.isOpen) {
+    return <SmsSendDetailListModalDialog key={modalKey} />;
+  }
+
   return null;
 };
 
@@ -31,6 +40,10 @@ const ModalViewer = () => {
   const setAlertModal = useSetRecoilState($modalByStorage(ModalKey.alertModalDialog));
   const setChangeResultModal = useSetRecoilState($modalByStorage(ModalKey.changeResultModalDialog));
   const setSmsSendModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
+  const setSmsSendDetailListModal = useSetRecoilState(
+    $modalByStorage(ModalKey.smsSendDetailListModalDialog),
+  );
+
   const { pathname } = useLocation();
 
   // TODO:(용재) 추후 더 나은 방법 찾아보기..
@@ -40,7 +53,11 @@ const ModalViewer = () => {
     if (!/\/application\/\d/g.test(pathname)) {
       setSmsSendModal({ key: ModalKey.smsSendModalDialog, isOpen: false });
     }
-  }, [setAlertModal, setChangeResultModal, setSmsSendModal, pathname]);
+    setSmsSendDetailListModal({
+      key: ModalKey.smsSendDetailListModalDialog,
+      isOpen: false,
+    });
+  }, [setAlertModal, setChangeResultModal, setSmsSendModal, pathname, setSmsSendDetailListModal]);
 
   return (
     <>

--- a/src/components/common/ModalViewer/ModalViewer.component.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.component.tsx
@@ -5,6 +5,7 @@ import { $modalByStorage, ModalKey, ModalKeyType } from '@/store';
 import {
   AlertModalDialog,
   ChangeResultModalDialog,
+  SmsSendDetailInfoModalDialog,
   SmsSendDetailListModalDialog,
   SmsSendModalDialog,
 } from '@/components';
@@ -33,6 +34,10 @@ const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
     return <SmsSendDetailListModalDialog key={modalKey} />;
   }
 
+  if (modalKey === ModalKey.smsSendDetailInfoModalDialog && modal.isOpen) {
+    return <SmsSendDetailInfoModalDialog key={modalKey} />;
+  }
+
   return null;
 };
 
@@ -42,6 +47,9 @@ const ModalViewer = () => {
   const setSmsSendModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
   const setSmsSendDetailListModal = useSetRecoilState(
     $modalByStorage(ModalKey.smsSendDetailListModalDialog),
+  );
+  const setSmsSendDetailInfoModal = useSetRecoilState(
+    $modalByStorage(ModalKey.smsSendDetailInfoModalDialog),
   );
 
   const { pathname } = useLocation();
@@ -57,7 +65,18 @@ const ModalViewer = () => {
       key: ModalKey.smsSendDetailListModalDialog,
       isOpen: false,
     });
-  }, [setAlertModal, setChangeResultModal, setSmsSendModal, pathname, setSmsSendDetailListModal]);
+    setSmsSendDetailInfoModal({
+      key: ModalKey.smsSendDetailInfoModalDialog,
+      isOpen: false,
+    });
+  }, [
+    setAlertModal,
+    setChangeResultModal,
+    setSmsSendModal,
+    pathname,
+    setSmsSendDetailListModal,
+    setSmsSendDetailInfoModal,
+  ]);
 
   return (
     <>

--- a/src/components/common/ModalViewer/ModalViewer.stories.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.stories.tsx
@@ -15,6 +15,10 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
   const handleControlChangeResultModal = useSetRecoilState(
     $modalByStorage(ModalKey.changeResultModalDialog),
   );
+  const handleControlSmsSendDetailInfoModal = useSetRecoilState(
+    $modalByStorage(ModalKey.smsSendDetailInfoModalDialog),
+  );
+
   return (
     <div>
       <ModalViewer />
@@ -128,6 +132,16 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
         }
       >
         SMS 발송(여러명)
+      </Button>
+      <Button
+        onClick={() =>
+          handleControlSmsSendDetailInfoModal({
+            key: ModalKey.smsSendDetailInfoModalDialog,
+            isOpen: true,
+          })
+        }
+      >
+        SMS 발송 상세내역
       </Button>
     </div>
   );

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useRecoilCallback } from 'recoil';
+import { useRecoilCallback, useSetRecoilState } from 'recoil';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { InputField, ModalWrapper, TitleWithContent, Textarea } from '@/components';
@@ -40,6 +40,16 @@ const SmsSendModalDialog = ({
 }: SmsSendModalDialogProps) => {
   const { handleAddToast } = useToast();
   const navigate = useNavigate();
+  const setSmsSendDetailListModal = useSetRecoilState(
+    $modalByStorage(ModalKey.smsSendDetailListModalDialog),
+  );
+
+  const handleOpenSmsSendDetailListModalDialog = () => {
+    setSmsSendDetailListModal({
+      key: ModalKey.smsSendDetailListModalDialog,
+      isOpen: true,
+    });
+  };
 
   const handleRemoveCurrentModal = useRecoilCallback(({ set }) => () => {
     set($modalByStorage(ModalKey.smsSendModalDialog), {
@@ -117,7 +127,7 @@ const SmsSendModalDialog = ({
               <TitleWithContent title="총 발송 인원">{selectedList.length}</TitleWithContent>
               {/* // TODO:(용재) 발송 인원 상세 리스트 모달 구현시 여는 로직 추가 */}
               {!isSendFailed && (
-                <button type="button">
+                <button type="button" onClick={handleOpenSmsSendDetailListModalDialog}>
                   발송 인원 상세보기
                   <ArrowRight />
                 </button>

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
@@ -125,7 +125,6 @@ const SmsSendModalDialog = ({
           <>
             <Styled.TitleArea>
               <TitleWithContent title="총 발송 인원">{selectedList.length}</TitleWithContent>
-              {/* // TODO:(용재) 발송 인원 상세 리스트 모달 구현시 여는 로직 추가 */}
               {!isSendFailed && (
                 <button type="button" onClick={handleOpenSmsSendDetailListModalDialog}>
                   발송 인원 상세보기

--- a/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component.tsx
+++ b/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useRecoilCallback } from 'recoil';
+import { ModalWrapper } from '@/components';
+import { $modalByStorage, ModalKey } from '@/store';
+
+const SmsSendDetailInfoModalDialog = () => {
+  const handleRemoveCurrentModal = useRecoilCallback(({ set }) => () => {
+    set($modalByStorage(ModalKey.smsSendDetailInfoModalDialog), {
+      key: ModalKey.smsSendDetailInfoModalDialog,
+      isOpen: false,
+    });
+  });
+
+  const props = {
+    heading: 'SMS 발송 상세내역',
+    footer: {
+      cancelButton: {
+        label: '닫기',
+      },
+    },
+    handleCloseModal: handleRemoveCurrentModal,
+    isContentScroll: false,
+  };
+
+  // TODO: 테이블 추가
+  return <ModalWrapper {...props} />;
+};
+
+export default SmsSendDetailInfoModalDialog;

--- a/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.stories.tsx
+++ b/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SmsSendDetailInfoModalDialog from './SmsSendDetailInfoModalDialog.component';
+
+export default {
+  title: 'Modal/Sms Send Detail Info Modal Dialog',
+  component: SmsSendDetailInfoModalDialog,
+} as ComponentMeta<typeof SmsSendDetailInfoModalDialog>;
+
+const Template: ComponentStory<typeof SmsSendDetailInfoModalDialog> = () => (
+  <SmsSendDetailInfoModalDialog />
+);
+
+export const smsSendDetailInfoModalDialog = Template.bind({});

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useRecoilCallback } from 'recoil';
+import { ModalWrapper } from '@/components';
+import { $modalByStorage, ModalKey } from '@/store';
+
+const SmsSendDetailListModalDialog = () => {
+  const handleRemoveCurrentModal = useRecoilCallback(({ set }) => () => {
+    set($modalByStorage(ModalKey.smsSendDetailListModalDialog), {
+      key: ModalKey.smsSendDetailListModalDialog,
+      isOpen: false,
+    });
+  });
+
+  const props = {
+    heading: '발송인원 상세 리스트',
+    footer: {
+      cancelButton: {
+        label: '닫기',
+      },
+    },
+    handleCloseModal: handleRemoveCurrentModal,
+    isContentScroll: false,
+  };
+
+  // TODO: 테이블 추가
+  return <ModalWrapper {...props} />;
+};
+
+export default SmsSendDetailListModalDialog;

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.stories.tsx
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SmsSendDetailListModalDialog from './SmsSendDetailListModalDialog.component';
+
+export default {
+  title: 'Modal/Sms Send Detail List Modal Dialog',
+  component: SmsSendDetailListModalDialog,
+} as ComponentMeta<typeof SmsSendDetailListModalDialog>;
+
+const Template: ComponentStory<typeof SmsSendDetailListModalDialog> = () => (
+  <SmsSendDetailListModalDialog />
+);
+
+export const smsSendDetailListModalDialog = Template.bind({});

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -1,2 +1,3 @@
 export { default as ChangeResultModalDialog } from './ChangeResultModalDialog/ChangeResultModalDialog.component';
+export { default as SmsSendDetailInfoModalDialog } from './SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component';
 export { default as SmsSendDetailListModalDialog } from './SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -1,1 +1,2 @@
 export { default as ChangeResultModalDialog } from './ChangeResultModalDialog/ChangeResultModalDialog.component';
+export { default as SmsSendDetailListModalDialog } from './SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -10,6 +10,7 @@ export const ModalKey = {
   alertModalDialog: 'alertModalDialog',
   smsSendModalDialog: 'smsSendModalDialog',
   changeResultModalDialog: 'changeResultModalDialog',
+  smsSendDetailInfoModalDialog: 'smsSendDetailInfoModalDialog',
   smsSendDetailListModalDialog: 'smsSendDetailListModalDialog',
 } as const;
 

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -10,6 +10,7 @@ export const ModalKey = {
   alertModalDialog: 'alertModalDialog',
   smsSendModalDialog: 'smsSendModalDialog',
   changeResultModalDialog: 'changeResultModalDialog',
+  smsSendDetailListModalDialog: 'smsSendDetailListModalDialog',
 } as const;
 
 export type ModalKeyType = ValueOf<typeof ModalKey>;


### PR DESCRIPTION
## 변경사항

- 발송인원 상세 리스트, SMS 발송 상세내역 Table 추가 전 베이스 모달 다이얼로그 컴포넌트 추가
- SMS 발송 컴포넌트에 발송인원 상세 리스트 모달 연결

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)