### PR TITLE
지원설문지 상세 합격여부 Select를 SCREENING_PASSED 기준으로 validate

### DIFF
--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -18,7 +18,11 @@ import { SelectOption, SelectSize } from '@/components/common/Select/Select.comp
 import { useOnClickOutSide } from '@/hooks';
 import { rangeArray } from '@/utils';
 import { postUpdateResult } from '@/api';
-import { ApplicationConfirmationStatusInDto, ApplicationUpdateResultByIdRequest } from '@/types';
+import {
+  ApplicationConfirmationStatusInDto,
+  ApplicationResultStatusInDto,
+  ApplicationUpdateResultByIdRequest,
+} from '@/types';
 import { $modalByStorage, ModalKey } from '@/store';
 
 interface FormValues {
@@ -86,16 +90,21 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
 
   useOnClickOutSide(outerRef, () => setIsDatePickerOpened(false));
 
-  const applicationResultOptions = useMemo(
-    () =>
-      Object.values(ApplicationResultStatus).reduce<SelectOption[]>(
-        (acc: SelectOption[], cur: ApplicationResultStatusType, index) => {
-          return [...acc, { value: Object.keys(ApplicationResultStatus)[index], label: cur }];
-        },
-        [],
-      ),
-    [],
-  );
+  const applicationResultOptions = useMemo(() => {
+    const resultOption = Object.values(ApplicationResultStatus).reduce<SelectOption[]>(
+      (acc: SelectOption[], cur: ApplicationResultStatusType, index) => [
+        ...acc,
+        { value: Object.keys(ApplicationResultStatus)[index], label: cur },
+      ],
+      [],
+    );
+
+    if (resultStatus === ApplicationResultStatusInDto.SCREENING_PASSED) {
+      return resultOption.slice(3, 6);
+    }
+
+    return resultOption.slice(0, 4);
+  }, [resultStatus]);
 
   const timeOptions = useMemo(
     () =>

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.stories.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.stories.tsx
@@ -19,14 +19,6 @@ applicationPanelTBD.args = {
   interviewDate: '2022-02-22T08:10:11+09:00',
 };
 
-export const applicationPanelREJECTED = Template.bind({});
-
-applicationPanelREJECTED.args = {
-  confirmationStatus: 'INTERVIEW_CONFIRM_REJECTED',
-  resultStatus: 'NOT_RATED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
-};
-
 export const 서류_불합격 = Template.bind({});
 
 서류_불합격.args = {

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.styled.ts
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.styled.ts
@@ -67,6 +67,7 @@ export const SelectWrapper = styled.div<StyledSelectWrapperProps>`
     justify-content: space-between;
     height: 4.8rem;
     padding: 0.8rem 1.2rem;
+    font-weight: 400;
     background-color: ${theme.colors.white};
     border: 0.1rem solid ${theme.colors.gray30};
     border-color: ${isDatePickerOpened ? theme.colors.purple70 : theme.colors.gray30};
@@ -97,6 +98,10 @@ export const SelectTimeField = styled.div`
   ul {
     height: 26.8rem;
     overflow-y: auto;
+  }
+
+  & div {
+    opacity: 1;
   }
 `;
 


### PR DESCRIPTION
## 변경사항

- 서류 합격을 기준으로 지원설문지 상세 합격여부 Select option을 아래 두가지 경우로 분기처리하도록 함
  - 서류 합격이 아닌경우 선택 가능한 옵션 => 미검토, 서류 보류, 서류 불합격, 서류 합격
  - 서류 합격인 경우 선택 가능한 옵션 => 서류 합격, 최종 불합격, 최종 합격
  - https://deploy-preview-146--affectionate-jones-aa31c6.netlify.app/?path=/story/applicationdetail-application-panel--application-panel-tbd
  - 불필요한 선택을 막기위한 용도

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)