### PR TITLE
ApplicationPanel의 예외사항을 고려하여 리팩토링

### DIFF
--- a/src/api/application.ts
+++ b/src/api/application.ts
@@ -32,7 +32,7 @@ export const postUpdateResult = ({
   interviewStartedAt,
 }: ApplicationUpdateResultByIdRequest): Promise<BaseResponse<MeResponse>> =>
   http.post({
-    url: `/applications/${applicationId}`,
+    url: `/applications/${applicationId}/update-result`,
     data: {
       applicationResultStatus,
       interviewEndedAt,

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -57,7 +57,7 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
       ['SCREENING_PASSED', 'INTERVIEW_FAILED', 'INTERVIEW_PASSED'].some(
         (each) => each === resultStatus,
       ),
-    [],
+    [resultStatus],
   );
   const [isShowInterviewSchedule, setIsShowInterviewSchedule] = useState(isScreeningPassed);
   const [isEdit, setIsEdit] = useState(false);

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -245,7 +245,7 @@ const ApplicationPanel = ({
   const methods = useForm<FormValues>({
     defaultValues: {
       applicationResultStatus: resultStatus,
-      interviewStartedAt: interviewDate || dayjs.utc().hour(8).minute(0).format(),
+      interviewStartedAt: interviewDate || dayjs.utc().add(1, 'd').hour(8).minute(0).format(),
       isEdit: false,
     },
   });

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -243,7 +243,9 @@ const ApplicationPanel = ({
   const methods = useForm<FormValues>({
     defaultValues: {
       applicationResultStatus: resultStatus,
-      interviewStartedAt: interviewDate || dayjs().add(1, 'd').hour(8).minute(0).format(),
+      interviewStartedAt: interviewDate
+        ? dayjs.utc(interviewDate).format()
+        : dayjs().add(1, 'd').hour(8).minute(0).format(),
       isEdit: false,
     },
   });

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -210,7 +210,7 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
             confirmationStatus === ApplicationConfirmationStatusInDto.FINAL_CONFIRM_REJECTED
           }
         >
-          {formatDate(interviewDate, 'YYYY년 M월 D일(ddd) a hh시 mm분')}
+          {formatDate(dayjs.utc(interviewDate).format(), 'YYYY년 M월 D일(ddd) a hh시 mm분')}
         </TitleWithContent>
       )}
       <Styled.ButtonContainer>
@@ -256,7 +256,7 @@ const ApplicationPanel = ({
         const requestDto: ApplicationUpdateResultByIdRequest = {
           applicationResultStatus,
           interviewStartedAt: dayjs.utc(interviewStartedAt).format(),
-          interviewEndedAt: dayjs.utc(interviewStartedAt).format(),
+          interviewEndedAt: dayjs.utc(interviewStartedAt).add(1, 's').format(),
           applicationId,
         };
 

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.stories.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.stories.tsx
@@ -16,7 +16,6 @@ export const applicationPanelTBD = Template.bind({});
 applicationPanelTBD.args = {
   confirmationStatus: 'TO_BE_DETERMINED',
   resultStatus: 'NOT_RATED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
 };
 
 export const 서류_불합격 = Template.bind({});
@@ -24,7 +23,6 @@ export const 서류_불합격 = Template.bind({});
 서류_불합격.args = {
   confirmationStatus: 'NOT_APPLICABLE',
   resultStatus: 'SCREENING_FAILED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
 };
 
 export const 서류_합격_면접_확인_대기 = Template.bind({});
@@ -32,7 +30,7 @@ export const 서류_합격_면접_확인_대기 = Template.bind({});
 서류_합격_면접_확인_대기.args = {
   confirmationStatus: 'INTERVIEW_CONFIRM_WAITING',
   resultStatus: 'SCREENING_PASSED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
+  interviewDate: '2030-02-22T08:10:00+09:00',
 };
 
 export const 서류_합격_면접_수락 = Template.bind({});
@@ -40,7 +38,7 @@ export const 서류_합격_면접_수락 = Template.bind({});
 서류_합격_면접_수락.args = {
   confirmationStatus: 'INTERVIEW_CONFIRM_ACCEPTED',
   resultStatus: 'SCREENING_PASSED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
+  interviewDate: '2030-02-22T08:10:00+09:00',
 };
 
 export const 서류_합격_면접_거절 = Template.bind({});
@@ -48,5 +46,5 @@ export const 서류_합격_면접_거절 = Template.bind({});
 서류_합격_면접_거절.args = {
   confirmationStatus: 'INTERVIEW_CONFIRM_REJECTED',
   resultStatus: 'SCREENING_PASSED',
-  interviewDate: '2022-02-22T08:10:11+09:00',
+  interviewDate: '2030-02-22T08:10:00+09:00',
 };

--- a/src/components/common/DatePicker/DatePicker.component.tsx
+++ b/src/components/common/DatePicker/DatePicker.component.tsx
@@ -71,7 +71,10 @@ const DayCell = ({
     ...resetProps,
     disabled: isDisabled,
     today: date.isSame(today, 'day'),
-    selected: date.isSame(selectedDate),
+    selected:
+      date.isSame(selectedDate, 'year') &&
+      date.isSame(selectedDate, 'month') &&
+      date.isSame(selectedDate, 'date'),
   };
 
   return <Styled.DatePickerTd {...props}>{date.format('D')}</Styled.DatePickerTd>;

--- a/src/components/common/DatePicker/DatePicker.component.tsx
+++ b/src/components/common/DatePicker/DatePicker.component.tsx
@@ -82,11 +82,12 @@ const DayCell = ({
 
 export interface DatePickerProps {
   handleSelectDate: (clickedDate: Dayjs) => void;
-  selectedDate: Dayjs | null;
+  selectedDate: Dayjs;
 }
 
 const DatePicker = ({ handleSelectDate, selectedDate }: DatePickerProps) => {
-  const [date, setDate] = useState<Dayjs>(selectedDate || dayjs());
+  const [date, setDate] = useState<Dayjs>(selectedDate);
+
   const rows = handleGenerateDateRows(date);
 
   const handleChangeMonth = (by: 'next' | 'prev') => {

--- a/src/components/common/DatePicker/DatePicker.stories.tsx
+++ b/src/components/common/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import DatePicker, { DatePickerProps } from './DatePicker.component';
 
 export default {
@@ -9,7 +9,7 @@ export default {
 } as ComponentMeta<typeof DatePicker>;
 
 const Template: ComponentStory<typeof DatePicker> = (args: DatePickerProps) => {
-  const [selectedDate, setSelectedDate] = useState<Dayjs | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs());
   const handleSelectDate = (clickedDate: Dayjs) => {
     setSelectedDate(clickedDate);
   };

--- a/src/types/dto/application.ts
+++ b/src/types/dto/application.ts
@@ -78,7 +78,7 @@ export interface ApplicationByIdRequest {
 export interface ApplicationUpdateResultByIdRequest extends ApplicationByIdRequest {
   applicationResultStatus: ApplicationResultStatusInDtoType;
   interviewEndedAt?: string;
-  interviewStartedAt: string;
+  interviewStartedAt?: string;
 }
 
 export interface ApplicationUpdateMultipleResultRequest {


### PR DESCRIPTION
## 변경사항

- DatePicker에서 selected 된 날짜를 년,월,일까지만 비교하게 함
- postUpdateResult url 잘못된 부분을 수정
- useFormContext로 date 값을 읽고 수정하도록 처리
- useForm에 defaultValue 추가
- ApplicationPanel에 isScreening, isShowInterviewSchedule 상태를 분리해서 분기처리
  - 인터뷰 이후 절차가 확정된 상황인지, 합격 여부 설정시 면접 일정을 노출해야되는 상황인지를 분리시킴

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)