### PR TITLE
dayjs utc 변환시 Z 기준으로 시간이 변환되던 부분 수정

### DIFF
--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -210,7 +210,7 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
             confirmationStatus === ApplicationConfirmationStatusInDto.FINAL_CONFIRM_REJECTED
           }
         >
-          {formatDate(dayjs.utc(interviewDate).format(), 'YYYY년 M월 D일(ddd) a hh시 mm분')}
+          {formatDate(dayjs(interviewDate).format(), 'YYYY년 M월 D일(ddd) a hh시 mm분')}
         </TitleWithContent>
       )}
       <Styled.ButtonContainer>
@@ -244,7 +244,7 @@ const ApplicationPanel = ({
     defaultValues: {
       applicationResultStatus: resultStatus,
       interviewStartedAt: interviewDate
-        ? dayjs.utc(interviewDate).format()
+        ? dayjs(interviewDate).format()
         : dayjs().add(1, 'd').hour(8).minute(0).format(),
       isEdit: false,
     },
@@ -257,8 +257,12 @@ const ApplicationPanel = ({
       async ({ applicationResultStatus, interviewStartedAt }: FormValues) => {
         const requestDto: ApplicationUpdateResultByIdRequest = {
           applicationResultStatus,
-          interviewStartedAt: dayjs.utc(interviewStartedAt).format(),
-          interviewEndedAt: dayjs.utc(interviewStartedAt).add(1, 's').format(),
+          interviewStartedAt: dayjs(interviewStartedAt).utc(true).format().replace('Z', ''),
+          interviewEndedAt: dayjs(interviewStartedAt)
+            .utc(true)
+            .add(1, 's')
+            .format()
+            .replace('Z', ''),
           applicationId,
         };
 

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -14,7 +14,7 @@ import ApplicationStatusBadge, {
   ApplicationResultStatusKeyType,
   ApplicationResultStatusType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
-import { formatDate } from '@/utils/date';
+import { convertToUtc, formatDate } from '@/utils/date';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import { useOnClickOutSide, useToast } from '@/hooks';
 import { rangeArray, request } from '@/utils';
@@ -257,12 +257,8 @@ const ApplicationPanel = ({
       async ({ applicationResultStatus, interviewStartedAt }: FormValues) => {
         const requestDto: ApplicationUpdateResultByIdRequest = {
           applicationResultStatus,
-          interviewStartedAt: dayjs(interviewStartedAt).utc(true).format().replace('Z', ''),
-          interviewEndedAt: dayjs(interviewStartedAt)
-            .utc(true)
-            .add(1, 's')
-            .format()
-            .replace('Z', ''),
+          interviewStartedAt: convertToUtc(interviewStartedAt),
+          interviewEndedAt: convertToUtc(dayjs(interviewStartedAt).add(1, 's').format()),
           applicationId,
         };
 

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -14,7 +14,7 @@ import ApplicationStatusBadge, {
   ApplicationResultStatusKeyType,
   ApplicationResultStatusType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
-import { convertToUtc, formatDate } from '@/utils/date';
+import { toUtcWithoutChangingTime, formatDate } from '@/utils/date';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import { useOnClickOutSide, useToast } from '@/hooks';
 import { rangeArray, request } from '@/utils';
@@ -257,8 +257,10 @@ const ApplicationPanel = ({
       async ({ applicationResultStatus, interviewStartedAt }: FormValues) => {
         const requestDto: ApplicationUpdateResultByIdRequest = {
           applicationResultStatus,
-          interviewStartedAt: convertToUtc(interviewStartedAt),
-          interviewEndedAt: convertToUtc(dayjs(interviewStartedAt).add(1, 's').format()),
+          interviewStartedAt: toUtcWithoutChangingTime(interviewStartedAt),
+          interviewEndedAt: toUtcWithoutChangingTime(
+            dayjs(interviewStartedAt).add(1, 's').format(),
+          ),
           applicationId,
         };
 

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -210,7 +210,7 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
             confirmationStatus === ApplicationConfirmationStatusInDto.FINAL_CONFIRM_REJECTED
           }
         >
-          {formatDate(dayjs(interviewDate).format(), 'YYYY년 M월 D일(ddd) a hh시 mm분')}
+          {formatDate(interviewDate, 'YYYY년 M월 D일(ddd) a hh시 mm분')}
         </TitleWithContent>
       )}
       <Styled.ButtonContainer>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,6 +13,6 @@ export const formatDate = (date: string | Date, format: DateFormat) => {
   return dayjs(date).format(format);
 };
 
-export const convertToUtc = (date: string | Date) => {
+export const toUtcWithoutChangingTime = (date: string | Date) => {
   return dayjs(date).utc(true).format().replace('Z', '');
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,3 +12,7 @@ type DateFormat =
 export const formatDate = (date: string | Date, format: DateFormat) => {
   return dayjs(date).format(format);
 };
+
+export const convertToUtc = (date: string | Date) => {
+  return dayjs(date).utc(true).format().replace('Z', '');
+};


### PR DESCRIPTION
## 변경사항

- dayjs utc 변환시 Z 기준으로 시간이 변환되던 부분 수정
<img width="795" alt="Screen Shot 2022-03-25 at 7 41 10 AM" src="https://user-images.githubusercontent.com/16266103/160022871-6735bb75-9258-4dc4-a72b-4a3d74ed086d.png">



### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)