### PR TITLE
Application list page에 SMS 일괄전송 모달 적용

### DIFF
--- a/src/components/ApplicationDetail/MessageListPanel/MessageListPanel.component.tsx
+++ b/src/components/ApplicationDetail/MessageListPanel/MessageListPanel.component.tsx
@@ -6,7 +6,7 @@ import UserProfile, {
 import { TitleWithContent } from '..';
 import * as Styled from './MessageListPanel.styled';
 import { Button } from '@/components';
-import { MemberPositionType } from '@/types';
+import { MemberPositionType, ApplicationResponse } from '@/types';
 import { $modalByStorage, ModalKey } from '@/store';
 import { formatDate } from '@/utils/date';
 import { SmsStatus, SmsStatusType } from '@/types/dto/sms';
@@ -54,10 +54,10 @@ const MessageInfo = ({
 
 export interface MessageListPanelProps {
   smsRequests: MessageInfoProps[];
-  id: number;
+  application: ApplicationResponse;
 }
 
-const MessageListPanel = ({ smsRequests, id }: MessageListPanelProps) => {
+const MessageListPanel = ({ smsRequests, application }: MessageListPanelProps) => {
   const handleControlModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
 
   return (
@@ -71,7 +71,7 @@ const MessageListPanel = ({ smsRequests, id }: MessageListPanelProps) => {
             handleControlModal({
               key: ModalKey.smsSendModalDialog,
               props: {
-                selectedList: [Number(id)],
+                selectedApplications: [application],
               },
               isOpen: true,
             })

--- a/src/components/common/ModalViewer/ModalViewer.component.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.component.tsx
@@ -12,6 +12,7 @@ import {
 import { AlertModalDialogProps } from '../AlertModalDialog/AlertModalDialog.component';
 import { ChangeResultModalDialogProps } from '@/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component';
 import { SmsSendModalDialogProps } from '../SmsSendModalDialog/SmsSendModalDialog.component';
+import { SmsSendDetailListModalDialogProps } from '../../modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';
 
 const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
   const modal = useRecoilValue($modalByStorage(modalKey));
@@ -30,8 +31,13 @@ const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
     return <SmsSendModalDialog key={modalKey} {...(modal.props as SmsSendModalDialogProps)} />;
   }
 
-  if (modalKey === ModalKey.smsSendDetailListModalDialog && modal.isOpen) {
-    return <SmsSendDetailListModalDialog key={modalKey} />;
+  if (modalKey === ModalKey.smsSendDetailListModalDialog && modal.isOpen && modal.props) {
+    return (
+      <SmsSendDetailListModalDialog
+        key={modalKey}
+        {...(modal.props as SmsSendDetailListModalDialogProps)}
+      />
+    );
   }
 
   if (modalKey === ModalKey.smsSendDetailInfoModalDialog && modal.isOpen) {

--- a/src/components/common/ModalViewer/ModalViewer.stories.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.stories.tsx
@@ -5,6 +5,36 @@ import ModalViewer from './ModalViewer.component';
 import { Button, Toast } from '@/components';
 import { $modalByStorage, $toast, ModalKey } from '@/store';
 
+const mockApplication = {
+  applicant: {
+    applicantId: 0,
+    createdAt: '2022-02-19T10:06:37.439Z',
+    email: 'string',
+    name: 'string',
+    phoneNumber: 'string',
+    status: 'ACTIVE',
+    updatedAt: '2022-02-19T10:06:37.439Z',
+  },
+  applicationId: 0,
+  confirmationStatus: 'FINAL_CONFIRM_ACCEPTED',
+  createdAt: '2022-02-19T10:06:37.439Z',
+  result: {
+    interviewEndedAt: '2022-02-19T10:06:37.439Z',
+    interviewStartedAt: '2022-02-19T10:06:37.439Z',
+    status: 'INTERVIEW_FAILED',
+  },
+  team: {
+    createdAt: '2022-02-19T10:06:37.439Z',
+    createdBy: 'string',
+    name: 'string',
+    teamId: 0,
+    updatedAt: '2022-02-19T10:06:37.439Z',
+    updatedBy: 'string',
+  },
+  updatedAt: '2022-02-19T10:06:37.439Z',
+  submittedAt: '2022-02-19T10:06:37.439Z',
+};
+
 export default {
   title: 'Modal Viewer',
 } as ComponentMeta<typeof ModalViewer>;
@@ -96,8 +126,7 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
           handleControlChangeResultModal({
             key: ModalKey.changeResultModalDialog,
             props: {
-              selectedList: [0, 1, 2, 3, 4],
-              selectedResults: ['SCREENING_PASSED', 'SCREENING_FAILED'],
+              selectedApplications: [mockApplication],
             },
             isOpen: true,
           })
@@ -110,7 +139,7 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
           handleControlSmsSendModal({
             key: ModalKey.smsSendModalDialog,
             props: {
-              selectedList: [0],
+              selectedApplications: [mockApplication],
             },
             isOpen: true,
           })
@@ -123,9 +152,7 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
           handleControlSmsSendModal({
             key: ModalKey.smsSendModalDialog,
             props: {
-              selectedList: [0, 1, 2, 3, 4],
-              selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
-              selectedResults: ['SCREENING_PASSED'],
+              selectedApplications: [mockApplication],
             },
             isOpen: true,
           })

--- a/src/components/common/ModalViewer/ModalViewer.stories.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.stories.tsx
@@ -124,8 +124,8 @@ const Template: ComponentStory<typeof ModalViewer> = () => {
             key: ModalKey.smsSendModalDialog,
             props: {
               selectedList: [0, 1, 2, 3, 4],
-              confirmationStatus: 'FINAL_CONFIRM_ACCEPTED',
-              resultStatus: 'SCREENING_PASSED',
+              selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
+              selectedResults: ['SCREENING_PASSED'],
             },
             isOpen: true,
           })

--- a/src/components/common/Pagination/Pagination.component.tsx
+++ b/src/components/common/Pagination/Pagination.component.tsx
@@ -17,19 +17,14 @@ export interface PageOptions {
 
 export interface PaginationProps {
   pageOptions: PageOptions;
-  selectableSize: boolean;
-  selectBoxPosition: ValueOf<typeof SelectPosition>;
+  selectableSize?: {
+    selectBoxPosition: ValueOf<typeof SelectPosition>;
+    handleChangeSize: (pagingSize: string) => void;
+  };
   handleChangePage: (page: number) => void;
-  handleChangeSize: (pagingSize: string) => void;
 }
 
-const Pagination = ({
-  pageOptions,
-  selectableSize,
-  selectBoxPosition,
-  handleChangePage,
-  handleChangeSize,
-}: PaginationProps) => {
+const Pagination = ({ pageOptions, selectableSize, handleChangePage }: PaginationProps) => {
   const { currentPage, startPage, endPage, totalPages, pagingSize } = pageOptions;
   return (
     <Styled.Navigation aria-label="Pagination">
@@ -47,8 +42,8 @@ const Pagination = ({
         {selectableSize && (
           <PagingSizeSelector
             pagingSize={pagingSize}
-            position={selectBoxPosition}
-            handleChangeSize={handleChangeSize}
+            position={selectableSize.selectBoxPosition}
+            handleChangeSize={selectableSize.handleChangeSize}
           />
         )}
       </Styled.Box>

--- a/src/components/common/Pagination/Pagination.stories.tsx
+++ b/src/components/common/Pagination/Pagination.stories.tsx
@@ -25,7 +25,7 @@ OnePageCase.args = {
     selectBoxPosition: 'bottom',
     handleChangeSize: () => {},
   },
-  handleChangePage: () => () => {},
+  handleChangePage: () => {},
 };
 
 export const FivePagesCase = Template.bind({});
@@ -41,7 +41,7 @@ FivePagesCase.args = {
     selectBoxPosition: 'bottom',
     handleChangeSize: () => {},
   },
-  handleChangePage: () => () => {},
+  handleChangePage: () => {},
 };
 
 export const TenPagesCase = Template.bind({});
@@ -57,7 +57,7 @@ TenPagesCase.args = {
     selectBoxPosition: 'bottom',
     handleChangeSize: () => {},
   },
-  handleChangePage: () => () => {},
+  handleChangePage: () => {},
 };
 
 export const TwentyFivePagesCase = Template.bind({});
@@ -73,7 +73,7 @@ TwentyFivePagesCase.args = {
     selectBoxPosition: 'bottom',
     handleChangeSize: () => {},
   },
-  handleChangePage: () => () => {},
+  handleChangePage: () => {},
 };
 
 export const UsingPagination = () => {

--- a/src/components/common/Pagination/Pagination.stories.tsx
+++ b/src/components/common/Pagination/Pagination.stories.tsx
@@ -21,9 +21,11 @@ OnePageCase.args = {
     startPage: 1,
     totalPages: 1,
   },
-  selectableSize: true,
+  selectableSize: {
+    selectBoxPosition: 'bottom',
+    handleChangeSize: () => {},
+  },
   handleChangePage: () => () => {},
-  handleChangeSize: () => {},
 };
 
 export const FivePagesCase = Template.bind({});
@@ -35,9 +37,11 @@ FivePagesCase.args = {
     startPage: 1,
     totalPages: 5,
   },
-  selectableSize: true,
+  selectableSize: {
+    selectBoxPosition: 'bottom',
+    handleChangeSize: () => {},
+  },
   handleChangePage: () => () => {},
-  handleChangeSize: () => {},
 };
 
 export const TenPagesCase = Template.bind({});
@@ -49,9 +53,11 @@ TenPagesCase.args = {
     startPage: 1,
     totalPages: 10,
   },
-  selectableSize: true,
+  selectableSize: {
+    selectBoxPosition: 'bottom',
+    handleChangeSize: () => {},
+  },
   handleChangePage: () => () => {},
-  handleChangeSize: () => {},
 };
 
 export const TwentyFivePagesCase = Template.bind({});
@@ -63,9 +69,11 @@ TwentyFivePagesCase.args = {
     startPage: 11,
     totalPages: 25,
   },
-  selectableSize: true,
+  selectableSize: {
+    selectBoxPosition: 'bottom',
+    handleChangeSize: () => {},
+  },
   handleChangePage: () => () => {},
-  handleChangeSize: () => {},
 };
 
 export const UsingPagination = () => {
@@ -76,10 +84,11 @@ export const UsingPagination = () => {
   return (
     <Pagination
       pageOptions={pageOptions}
-      selectableSize
+      selectableSize={{
+        selectBoxPosition: SelectPosition.bottom,
+        handleChangeSize,
+      }}
       handleChangePage={handleChangePage}
-      handleChangeSize={handleChangeSize}
-      selectBoxPosition={SelectPosition.bottom}
     />
   );
 };

--- a/src/components/common/Pagination/Pagination.stories.tsx
+++ b/src/components/common/Pagination/Pagination.stories.tsx
@@ -69,7 +69,9 @@ TwentyFivePagesCase.args = {
 };
 
 export const UsingPagination = () => {
-  const { pageOptions, handleChangePage, handleChangeSize } = usePagination(550);
+  const { pageOptions, handleChangePage, handleChangeSize } = usePagination({
+    totalCount: 550,
+  });
 
   return (
     <Pagination

--- a/src/components/common/Pagination/PagingSizeSelector/PagingSizeSelector.tsx
+++ b/src/components/common/Pagination/PagingSizeSelector/PagingSizeSelector.tsx
@@ -17,6 +17,7 @@ interface Props {
 }
 
 const PagingSizeSelector = ({ pagingSize, position, handleChangeSize }: Props) => {
+  const currentValue = OPTIONS.find((option) => option.value === pagingSize.toString());
   const handleChange = (option: SelectOption) => {
     handleChangeSize(option.value);
   };
@@ -26,7 +27,7 @@ const PagingSizeSelector = ({ pagingSize, position, handleChangeSize }: Props) =
       aria-label="Paging size selector"
       size="sm"
       position={position}
-      defaultValue={OPTIONS.find((option) => option.value === pagingSize.toString())}
+      currentValue={currentValue}
       options={OPTIONS}
       onChangeOption={handleChange}
     />

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
@@ -25,16 +25,16 @@ interface FormValues {
 
 export interface SmsSendModalDialogProps {
   selectedList: number[];
-  resultStatus?: ApplicationResultStatusKeyType;
-  confirmationStatus?: ApplicationConfirmationStatusKeyType;
+  selectedResults?: ApplicationResultStatusKeyType[];
+  selectedConfirmStatuses?: ApplicationConfirmationStatusKeyType[];
   isSendFailed?: boolean;
   messageContent?: string;
 }
 
 const SmsSendModalDialog = ({
   selectedList,
-  resultStatus,
-  confirmationStatus,
+  selectedResults,
+  selectedConfirmStatuses,
   isSendFailed = false,
   messageContent,
 }: SmsSendModalDialogProps) => {
@@ -121,7 +121,7 @@ const SmsSendModalDialog = ({
   return (
     <ModalWrapper {...props}>
       <Styled.SmsSendModalContainer>
-        {confirmationStatus && resultStatus && (
+        {selectedConfirmStatuses && selectedResults && (
           <>
             <Styled.TitleArea>
               <TitleWithContent title="총 발송 인원">{selectedList.length}</TitleWithContent>
@@ -134,10 +134,14 @@ const SmsSendModalDialog = ({
             </Styled.TitleArea>
             <Styled.StatusArea isSendFailed={isSendFailed}>
               <TitleWithContent title="사용자 확인 여부">
-                <ApplicationStatusBadge text={ApplicationConfirmationStatus[confirmationStatus]} />
+                {selectedConfirmStatuses?.map((each) => (
+                  <ApplicationStatusBadge key={each} text={ApplicationConfirmationStatus[each]} />
+                ))}
               </TitleWithContent>
               <TitleWithContent title="합격 여부">
-                <ApplicationStatusBadge text={ApplicationResultStatus[resultStatus]} />
+                {selectedResults?.map((each) => (
+                  <ApplicationStatusBadge key={each} text={ApplicationResultStatus[each]} />
+                ))}
               </TitleWithContent>
             </Styled.StatusArea>
             <Styled.Divider />

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
@@ -28,20 +28,22 @@ export interface SmsSendModalDialogProps {
   selectedApplications: ApplicationResponse[];
   isSendFailed?: boolean;
   messageContent?: string;
+  showSummary?: boolean;
 }
 
 const SmsSendModalDialog = ({
   selectedApplications,
   isSendFailed = false,
   messageContent,
+  showSummary = false,
 }: SmsSendModalDialogProps) => {
-  const selectedIds = selectedApplications.map((application) => application.applicationId);
-  const selectedResults: ApplicationResultStatusKeyType[] = uniqArray(
+  const selectedIds = selectedApplications.map((application) => application.applicant.applicantId);
+  const selectedResults = uniqArray(
     selectedApplications.map((application) => application.result.status),
-  );
-  const selectedConfirmStatuses: ApplicationConfirmationStatusKeyType[] = uniqArray(
+  ) as ApplicationResultStatusKeyType[];
+  const selectedConfirmStatuses = uniqArray(
     selectedApplications.map((application) => application.confirmationStatus),
-  );
+  ) as ApplicationConfirmationStatusKeyType[];
 
   const { handleAddToast } = useToast();
   const navigate = useNavigate();
@@ -120,7 +122,6 @@ const SmsSendModalDialog = ({
         label: '발송',
         onClick: handleSubmit(handleSendSms),
         type: 'submit',
-        // TODO:(@dididy) sms 작업 완료 시 아래 라인 삭제
       },
     },
     handleCloseModal: handleRemoveCurrentModal,
@@ -129,7 +130,7 @@ const SmsSendModalDialog = ({
   return (
     <ModalWrapper {...props}>
       <Styled.SmsSendModalContainer>
-        {selectedConfirmStatuses && selectedResults && (
+        {showSummary && (
           <>
             <Styled.TitleArea>
               <TitleWithContent title="총 발송 인원">{selectedIds.length}</TitleWithContent>

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.stories.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.stories.tsx
@@ -21,16 +21,16 @@ export const smsSendModalDialogWithResult = Template.bind({});
 
 smsSendModalDialogWithResult.args = {
   selectedList: [0, 4],
-  confirmationStatus: 'FINAL_CONFIRM_ACCEPTED',
-  resultStatus: 'SCREENING_PASSED',
+  selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
+  selectedResults: ['SCREENING_PASSED'],
 };
 
 export const smsSendModalDialogSendFailure = Template.bind({});
 
 smsSendModalDialogSendFailure.args = {
   selectedList: [0, 1, 2, 3, 4],
-  confirmationStatus: 'FINAL_CONFIRM_ACCEPTED',
-  resultStatus: 'SCREENING_PASSED',
+  selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
+  selectedResults: ['SCREENING_PASSED'],
   isSendFailed: true,
   messageContent: 'ABCD',
 };

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.stories.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.stories.tsx
@@ -2,6 +2,36 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SmsSendModalDialog, { SmsSendModalDialogProps } from './SmsSendModalDialog.component';
 
+const mockApplication = {
+  applicant: {
+    applicantId: 0,
+    createdAt: '2022-02-19T10:06:37.439Z',
+    email: 'string',
+    name: 'string',
+    phoneNumber: 'string',
+    status: 'ACTIVE',
+    updatedAt: '2022-02-19T10:06:37.439Z',
+  },
+  applicationId: 0,
+  confirmationStatus: 'FINAL_CONFIRM_ACCEPTED',
+  createdAt: '2022-02-19T10:06:37.439Z',
+  result: {
+    interviewEndedAt: '2022-02-19T10:06:37.439Z',
+    interviewStartedAt: '2022-02-19T10:06:37.439Z',
+    status: 'INTERVIEW_FAILED',
+  },
+  team: {
+    createdAt: '2022-02-19T10:06:37.439Z',
+    createdBy: 'string',
+    name: 'string',
+    teamId: 0,
+    updatedAt: '2022-02-19T10:06:37.439Z',
+    updatedBy: 'string',
+  },
+  updatedAt: '2022-02-19T10:06:37.439Z',
+  submittedAt: '2022-02-19T10:06:37.439Z',
+};
+
 export default {
   title: 'common/Sms Send Modal Dialog',
   component: SmsSendModalDialog,
@@ -14,23 +44,20 @@ const Template: ComponentStory<typeof SmsSendModalDialog> = (args: SmsSendModalD
 export const smsSendModalDialogNormal = Template.bind({});
 
 smsSendModalDialogNormal.args = {
-  selectedList: [0],
+  selectedApplications: [mockApplication],
 };
 
 export const smsSendModalDialogWithResult = Template.bind({});
 
 smsSendModalDialogWithResult.args = {
-  selectedList: [0, 4],
-  selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
-  selectedResults: ['SCREENING_PASSED'],
+  selectedApplications: [mockApplication],
+  showSummary: true,
 };
 
 export const smsSendModalDialogSendFailure = Template.bind({});
 
 smsSendModalDialogSendFailure.args = {
-  selectedList: [0, 1, 2, 3, 4],
-  selectedConfirmStatuses: ['FINAL_CONFIRM_ACCEPTED'],
-  selectedResults: ['SCREENING_PASSED'],
+  selectedApplications: [mockApplication],
   isSendFailed: true,
   messageContent: 'ABCD',
 };

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.styled.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.styled.tsx
@@ -65,6 +65,11 @@ export const StatusArea = styled.div<StyledStatusAreaProps>`
           display: flex;
           flex-direction: column;
           gap: 1.6rem;
+
+          & > div > span {
+            display: flex;
+            gap: 0.6rem;
+          }
         `}
   `}
 `;

--- a/src/components/common/Table/Table.component.tsx
+++ b/src/components/common/Table/Table.component.tsx
@@ -17,14 +17,12 @@ import Loading from '../Loading/Loading.component';
 import Checkbox from '../Checkbox/Checkbox.component';
 import { SORT_TYPE } from '@/constants';
 
-const NAV_BAR_AND_SEARCH_BAR_HEIGHT = 187;
-const TABLE_DEFAULT_HEIGHT = (window.innerHeight - NAV_BAR_AND_SEARCH_BAR_HEIGHT) / 10;
 export interface TableColumn<T extends object> {
   title: string;
   accessor?: NestedKeyOf<T>;
   idAccessor?: NestedKeyOf<T>;
   widthRatio: string;
-  renderCustomCell?: (cellVaule: unknown, id?: string) => ReactNode;
+  renderCustomCell?: (cellValue: unknown, id?: string) => ReactNode;
 }
 
 export interface SortType<T extends object> {
@@ -40,10 +38,9 @@ interface SortOptions<T extends object> {
 
 export interface TableProps<T extends object> {
   prefix: string;
-  maxHeight?: number;
   columns: TableColumn<T>[];
   rows: T[];
-  isLoading: boolean;
+  isLoading?: boolean;
   selectableRow?: {
     selectedCount: number;
     selectedRows: T[];
@@ -214,20 +211,15 @@ const TableColumnCell = <T extends object>({
 
 const Table = <T extends object>({
   prefix,
-  maxHeight = TABLE_DEFAULT_HEIGHT,
   columns,
   rows,
-  isLoading,
+  isLoading = false,
   selectableRow,
   sortOptions,
   supportBar: { totalCount, totalSummaryText, selectedSummaryText, buttons: supportButtons },
   pagination,
 }: TableProps<T>) => {
   const { selectedCount, selectedRows, setSelectedRows, handleSelectAll } = selectableRow || {};
-  const DEFAULT_ROW_HEIGHT = 5.2;
-  const INNER_TABLE_EXTERNAL_BODY_HEIGHT = 15.6;
-  const bodyHeight = maxHeight! - INNER_TABLE_EXTERNAL_BODY_HEIGHT;
-  const itemSizeInnerBody = Math.floor(bodyHeight / DEFAULT_ROW_HEIGHT);
   const isEmptyData = rows.length === 0;
 
   const checkedValues = useMemo(
@@ -268,7 +260,7 @@ const Table = <T extends object>({
   };
 
   return (
-    <Styled.TableContainer height={rows.length >= itemSizeInnerBody ? `${maxHeight}rem` : 'auto'}>
+    <Styled.TableContainer>
       <TableSupportBar
         totalSummaryText={totalSummaryText}
         selectedSummaryText={selectedSummaryText}
@@ -288,7 +280,7 @@ const Table = <T extends object>({
             ))}
           </colgroup>
           <Styled.TableHeader>
-            <Styled.TableRow height={DEFAULT_ROW_HEIGHT}>
+            <Styled.TableRow>
               {!!selectableRow && (
                 <RowCheckBox isChecked={allInAPageChecked} handleToggle={handleSelectAllRow} />
               )}
@@ -303,22 +295,20 @@ const Table = <T extends object>({
           </Styled.TableHeader>
         </Styled.Table>
         <Styled.TableBodyWrapper isLoading={isLoading}>
-          <Styled.Table>
-            {isEmptyData ? (
-              <Styled.TableBody isEmpty>
-                <Styled.TableRow height={DEFAULT_ROW_HEIGHT * 5}>
-                  <Styled.TableCell>
-                    <Styled.Center>
-                      <Styled.NoData>
-                        <QuestionFile />
-                        <div>데이터가 없습니다.</div>
-                      </Styled.NoData>
-                    </Styled.Center>
-                  </Styled.TableCell>
-                </Styled.TableRow>
-              </Styled.TableBody>
-            ) : (
-              <>
+          {isEmptyData ? (
+            <Styled.NoData>
+              <QuestionFile />
+              <div>데이터가 없습니다.</div>
+            </Styled.NoData>
+          ) : (
+            <>
+              {isLoading && (
+                <Loading
+                  dimmedColor={colors.whiteLoadingDimmed}
+                  spinnerColor={colors.whiteLoadingDimmed}
+                />
+              )}
+              <Styled.Table>
                 <colgroup>
                   {!!selectableRow && <col width="4%" />}
                   {columns.map((column, columnIndex) => (
@@ -326,14 +316,8 @@ const Table = <T extends object>({
                   ))}
                 </colgroup>
                 <Styled.TableBody>
-                  {isLoading && (
-                    <Loading
-                      dimmedColor={colors.whiteLoadingDimmed}
-                      spinnerColor={colors.whiteLoadingDimmed}
-                    />
-                  )}
                   {rows.map((row, rowIndex) => (
-                    <Styled.TableRow key={`${prefix}-row-${rowIndex}`} height={DEFAULT_ROW_HEIGHT}>
+                    <Styled.TableRow key={`${prefix}-row-${rowIndex}`}>
                       {!!selectableRow && (
                         <RowCheckBox
                           isChecked={checkedValues[rowIndex]}
@@ -354,9 +338,9 @@ const Table = <T extends object>({
                     </Styled.TableRow>
                   ))}
                 </Styled.TableBody>
-              </>
-            )}
-          </Styled.Table>
+              </Styled.Table>
+            </>
+          )}
         </Styled.TableBodyWrapper>
       </Styled.TableWrapper>
       {!isEmptyData && pagination}

--- a/src/components/common/Table/Table.stories.tsx
+++ b/src/components/common/Table/Table.stories.tsx
@@ -377,7 +377,6 @@ NoData.args = {
   prefix: 'application-form',
   columns: columns as TableColumn<object>[],
   rows: [],
-  maxHeight: 60,
   isLoading: false,
   supportBar: {
     totalCount: 0,
@@ -390,7 +389,6 @@ Default.args = {
   prefix: 'application-form',
   columns: columns as TableColumn<object>[],
   rows,
-  maxHeight: 60,
   isLoading: false,
   supportBar: {
     totalCount: rows.length,
@@ -403,7 +401,6 @@ Loading.args = {
   prefix: 'application-form',
   columns: columns as TableColumn<object>[],
   rows,
-  maxHeight: 60,
   isLoading: true,
   supportBar: {
     totalCount: rows.length,
@@ -416,7 +413,6 @@ CustomCell.args = {
   prefix: 'application-form',
   columns: columnsWithCustomCell as TableColumn<object>[],
   rows,
-  maxHeight: 60,
   isLoading: false,
   supportBar: {
     totalCount: rows.length,
@@ -429,7 +425,6 @@ Sortable.args = {
   prefix: 'application-form',
   columns: columnsWithCustomCell as TableColumn<object>[],
   rows,
-  maxHeight: 60,
   isLoading: false,
   supportBar: {
     totalCount: rows.length,
@@ -452,7 +447,6 @@ Selectable.args = {
   prefix: 'application-form',
   columns: columnsWithCustomCell as TableColumn<object>[],
   rows,
-  maxHeight: 60,
   isLoading: false,
   supportBar: {
     totalCount: rows.length,

--- a/src/components/common/Table/Table.styled.ts
+++ b/src/components/common/Table/Table.styled.ts
@@ -3,10 +3,8 @@ import styled from '@emotion/styled';
 import { SORT_TYPE } from '@/constants';
 import { ValueOf } from '@/types';
 
-export const TableContainer = styled.div<{ height: string }>`
-  ${({ height }) => css`
-    height: ${height};
-  `}
+export const TableContainer = styled.div`
+  height: 100%;
 `;
 
 export const TableWrapper = styled.div`
@@ -79,9 +77,9 @@ export const TableBody = styled.tbody<{ isEmpty?: boolean }>`
   `};
 `;
 
-export const TableRow = styled.tr<{ height: number }>`
-  ${({ theme, height }) => css`
-    height: ${height}rem;
+export const TableRow = styled.tr`
+  ${({ theme }) => css`
+    height: 5.2rem;
     border-bottom: ${theme.colors.gray20} solid 0.1rem;
   `}
 `;
@@ -128,22 +126,11 @@ export const CheckboxWrapper = styled(Center)`
   }
 `;
 
-// TODO: (@minsour) 애니메이션 스펙 확정 후 지우거나 적용할 예정
-// export const rotate = keyframes`
-//   100% {
-//     transform: rotate(180deg); // translate(-0.1rem, -0.27rem);
-//     transform: rotate(180deg) translate(-0.1rem, -0.27rem);
-//   }
-// `;
-
 export const CaretUpWrapper = styled.span<{ type: ValueOf<typeof SORT_TYPE> }>`
   ${({ type }) => css`
     ${type === SORT_TYPE.DESC &&
     css`
       & svg {
-        /* TODO: (@minsour) 애니메이션 스펙 확정 후 지우거나 적용할 예정;
-        transform: translate(-0.1rem, -0.27rem);
-        animation: rotate 0.5s ease forwards; */
         transform: rotate(180deg) translate(-0.1rem, -0.25rem);
       }
     `}
@@ -229,7 +216,9 @@ export const NoData = styled.div`
     gap: 2.6rem;
     align-items: center;
     justify-content: center;
+    height: 26rem;
     color: ${theme.colors.gray70};
+    border-bottom: ${theme.colors.gray20} solid 0.1rem;
   `}
 `;
 

--- a/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
+++ b/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
@@ -27,11 +27,13 @@ interface FormValues {
 export interface ChangeResultModalDialogProps {
   selectedList: number[];
   selectedResults: ApplicationResultStatusKeyType[];
+  refreshList?: () => void;
 }
 
 const ChangeResultModalDialog = ({
   selectedList,
   selectedResults,
+  refreshList,
 }: ChangeResultModalDialogProps) => {
   const selectedApplicationResultStatusRef = useRef<HTMLSelectElement>(null);
   const { handleAddToast } = useToast();
@@ -68,6 +70,7 @@ const ChangeResultModalDialog = ({
                     type: ToastType.success,
                     message: '성공적으로 합격여부를 변경했습니다.',
                   });
+                  refreshList?.();
                 },
                 onCompleted: () => {
                   set($modalByStorage(ModalKey.alertModalDialog), {

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
@@ -1,9 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useRecoilCallback } from 'recoil';
-import { ModalWrapper } from '@/components';
+import { ModalWrapper, Pagination, Table } from '@/components';
 import { $modalByStorage, ModalKey } from '@/store';
+import { SORT_TYPE } from '@/constants';
+import { usePagination } from '@/hooks';
+import * as Styled from './SmsSendDetailListModalDialog.styled';
 
-const SmsSendDetailListModalDialog = () => {
+const columns: TableColumn<ApplicationResponse>[] = [
+  {
+    title: '이름',
+    accessor: 'applicant.name',
+    idAccessor: 'applicationId',
+    widthRatio: '30%',
+  },
+  {
+    title: '전화번호',
+    accessor: 'applicant.phoneNumber',
+    widthRatio: '40%',
+  },
+  {
+    title: '지원플랫폼',
+    accessor: 'team.name',
+    widthRatio: '30%',
+  },
+];
+
+export interface SmsSendDetailListModalDialogProps {
+  selectedApplications: ApplicationResponse[];
+}
+
+const SmsSendDetailListModalDialog = ({
+  selectedApplications,
+}: SmsSendDetailListModalDialogProps) => {
   const handleRemoveCurrentModal = useRecoilCallback(({ set }) => () => {
     set($modalByStorage(ModalKey.smsSendDetailListModalDialog), {
       key: ModalKey.smsSendDetailListModalDialog,
@@ -11,7 +39,7 @@ const SmsSendDetailListModalDialog = () => {
     });
   });
 
-  const props = {
+  const modalProps = {
     heading: '발송인원 상세 리스트',
     footer: {
       cancelButton: {
@@ -22,8 +50,43 @@ const SmsSendDetailListModalDialog = () => {
     isContentScroll: false,
   };
 
-  // TODO: 테이블 추가
-  return <ModalWrapper {...props} />;
+  const { pageOptions, handleChangePage } = usePagination({
+    totalCount: 80, // selectedApplications.length,
+    pagingSize: 10,
+    pageButtonsSize: 7,
+    usingSearchParams: false,
+  });
+
+  const [sortTypes, setSortTypes] = useState<SortType<ApplicationResponse>[]>([
+    { accessor: 'applicant.name', type: SORT_TYPE.DEFAULT },
+    { accessor: 'team.name', type: SORT_TYPE.DEFAULT },
+  ]);
+
+  return (
+    <ModalWrapper {...modalProps}>
+      <Styled.TableWrapper>
+        <Table
+          prefix="application-sms"
+          width={60}
+          maxHeight={57}
+          columns={columns}
+          rows={selectedApplications}
+          supportBar={{
+            totalCount: selectedApplications.length,
+            totalSummaryText: '총 발송인원',
+          }}
+          sortOptions={{
+            sortTypes,
+            disableMultiSort: true,
+            handleSortColumn: (_sortTypes) => {
+              setSortTypes(_sortTypes);
+            },
+          }}
+          pagination={<Pagination pageOptions={pageOptions} handleChangePage={handleChangePage} />}
+        />
+      </Styled.TableWrapper>
+    </ModalWrapper>
+  );
 };
 
 export default SmsSendDetailListModalDialog;

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.stories.tsx
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.stories.tsx
@@ -8,7 +8,7 @@ export default {
 } as ComponentMeta<typeof SmsSendDetailListModalDialog>;
 
 const Template: ComponentStory<typeof SmsSendDetailListModalDialog> = () => (
-  <SmsSendDetailListModalDialog />
+  <SmsSendDetailListModalDialog selectedApplications={[]} />
 );
 
 export const smsSendDetailListModalDialog = Template.bind({});

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.styled.ts
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.styled.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const TableWrapper = styled.div`
+  width: 60rem;
+  padding: 0 2.4rem 1.2rem 2.4rem;
+`;

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.styled.ts
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.styled.ts
@@ -2,5 +2,6 @@ import styled from '@emotion/styled';
 
 export const TableWrapper = styled.div`
   width: 60rem;
+  height: 58.2rem;
   padding: 0 2.4rem 1.2rem 2.4rem;
 `;

--- a/src/hooks/usePagination.test.ts
+++ b/src/hooks/usePagination.test.ts
@@ -22,7 +22,7 @@ describe('usePagination', () => {
     const totalCount = 0;
 
     // When
-    const { result } = renderHook(() => usePagination(totalCount));
+    const { result } = renderHook(() => usePagination({ totalCount }));
     const { pageOptions } = result.current;
 
     // Then
@@ -40,7 +40,7 @@ describe('usePagination', () => {
     const totalCount = 10;
 
     // When
-    const { result } = renderHook(() => usePagination(totalCount));
+    const { result } = renderHook(() => usePagination({ totalCount }));
     const { pageOptions } = result.current;
 
     // Then
@@ -58,7 +58,7 @@ describe('usePagination', () => {
     const totalCount = 550;
 
     // When
-    const { result } = renderHook(() => usePagination(totalCount));
+    const { result } = renderHook(() => usePagination({ totalCount }));
     const { pageOptions } = result.current;
 
     // Then
@@ -79,7 +79,7 @@ describe('usePagination', () => {
     mockSearchParams.get.mockReturnValueOnce(page).mockReturnValueOnce(size);
 
     // When
-    const { result } = renderHook(() => usePagination(totalCount));
+    const { result } = renderHook(() => usePagination({ totalCount }));
     const { pageOptions } = result.current;
 
     // Then
@@ -97,7 +97,7 @@ describe('usePagination', () => {
     const totalCount = 550;
 
     // When, Then
-    const { result } = renderHook(() => usePagination(totalCount));
+    const { result } = renderHook(() => usePagination({ totalCount }));
     const { pageOptions, handleChangePage } = result.current;
 
     expect(pageOptions).toEqual({

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { URLSearchParamsInit, useSearchParams } from 'react-router-dom';
 import { PageOptions, FIRST_PAGE } from '@/components/common/Pagination/Pagination.component';
 
 const DEFAULT_PAGING_SIZE = 20;
@@ -10,6 +10,12 @@ interface GetPageOptionsParams {
   pageIndex: number;
   pagingSize: number;
   pageButtonsSize: number;
+}
+
+interface UsePaginationParams {
+  totalCount: number;
+  isReplaceUrl?: boolean;
+  pageButtonsSize?: number;
 }
 
 const getPageOptions = ({
@@ -31,7 +37,11 @@ const getPageOptions = ({
   };
 };
 
-const usePagination = (totalCount: number, pageButtonsSize = DEFAULT_PAGE_BUTTONS_SIZE) => {
+const usePagination = ({
+  totalCount,
+  isReplaceUrl = false,
+  pageButtonsSize = DEFAULT_PAGE_BUTTONS_SIZE,
+}: UsePaginationParams) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [pageOptions, setPageOptions] = useState<PageOptions>({
     currentPage: 0,
@@ -40,6 +50,12 @@ const usePagination = (totalCount: number, pageButtonsSize = DEFAULT_PAGE_BUTTON
     totalPages: 0,
     pagingSize: 0,
   });
+
+  const handleSearchParams = (urlSearchParams: URLSearchParamsInit) => {
+    setSearchParams(urlSearchParams, {
+      replace: isReplaceUrl,
+    });
+  };
 
   const handleChangePage = (page: number) => {
     if (page === 0) return;
@@ -53,7 +69,7 @@ const usePagination = (totalCount: number, pageButtonsSize = DEFAULT_PAGE_BUTTON
     const { currentPage } = newPageOptions;
 
     searchParams.set('page', currentPage.toString());
-    setSearchParams(searchParams);
+    handleSearchParams(searchParams);
   };
 
   const handleChangeSize = (pagingSize: string) => {
@@ -73,7 +89,7 @@ const usePagination = (totalCount: number, pageButtonsSize = DEFAULT_PAGE_BUTTON
     }
 
     searchParams.set('size', pagingSize);
-    setSearchParams(searchParams);
+    handleSearchParams(searchParams);
   };
 
   useEffect(() => {
@@ -89,7 +105,7 @@ const usePagination = (totalCount: number, pageButtonsSize = DEFAULT_PAGE_BUTTON
     });
 
     if (newPageOptions.currentPage > newPageOptions.endPage) {
-      setSearchParams({
+      handleSearchParams({
         page: newPageOptions.endPage.toString(),
         size: newPageOptions.pagingSize.toString(),
       });

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -101,7 +101,6 @@ const usePagination = ({
 
     const currentPage = searchParams.get('page');
     const currentSize = usingSearchParams ? searchParams.get('size') : '';
-    console.log({ currentSize });
     const newPageOptions = getPageOptions({
       totalCount,
       pageIndex: currentPage ? parseInt(currentPage, 10) - 1 : FIRST_PAGE - 1,

--- a/src/pages/ApplicationDetailView/ApplicationDetailView.page.tsx
+++ b/src/pages/ApplicationDetailView/ApplicationDetailView.page.tsx
@@ -71,7 +71,7 @@ const ApplicationDetailView = () => {
             interviewDate={data.result.interviewStartedAt}
             applicationId={id as string}
           />
-          <MessageListPanel smsRequests={data.smsRequests} id={data.applicant.applicantId} />
+          <MessageListPanel smsRequests={data.smsRequests} application={data} />
         </Styled.Aside>
       </div>
     </Styled.ApplicationDetailViewPage>

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -137,9 +137,9 @@ const ApplicationFormList = () => {
     tableRows.data || [],
   );
 
-  const { pageOptions, handleChangePage, handleChangeSize } = usePagination(
-    tableRows.page?.totalCount,
-  );
+  const { pageOptions, handleChangePage, handleChangeSize } = usePagination({
+    totalCount: tableRows.page?.totalCount,
+  });
 
   const { makeDirty, isDirty } = useDirty(1);
 

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -204,10 +204,11 @@ const ApplicationFormList = () => {
         pagination={
           <Pagination
             pageOptions={pageOptions}
-            selectableSize
-            selectBoxPosition={loadedTableRows.length > 3 ? 'top' : 'bottom'}
+            selectableSize={{
+              selectBoxPosition: loadedTableRows.length > 3 ? 'top' : 'bottom',
+              handleChangeSize,
+            }}
             handleChangePage={handleChangePage}
-            handleChangeSize={handleChangeSize}
           />
         }
       />

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -153,9 +153,9 @@ const ApplicationList = () => {
     tableRows.data || [],
   );
 
-  const { pageOptions, handleChangePage, handleChangeSize } = usePagination(
-    tableRows.page?.totalCount,
-  );
+  const { pageOptions, handleChangePage, handleChangeSize } = usePagination({
+    totalCount: tableRows.page?.totalCount,
+  });
 
   const { makeDirty, isDirty } = useDirty(1);
 

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -8,7 +8,12 @@ import React, {
   FormEvent,
 } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useRecoilStateLoadable, useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  useRecoilRefresher_UNSTABLE,
+  useRecoilStateLoadable,
+  useRecoilValue,
+  useSetRecoilState,
+} from 'recoil';
 import * as api from '@/api';
 import { Button, Pagination, SearchOptionBar, Table, TeamNavigationTabs } from '@/components';
 import { formatDate, uniqArray } from '@/utils';
@@ -146,6 +151,7 @@ const ApplicationList = () => {
 
   const [totalCount, setTotalCount] = useState(0);
   const [{ state, contents: tableRows }] = useRecoilStateLoadable($applications(applicationParams));
+  const refreshApplications = useRecoilRefresher_UNSTABLE($applications(applicationParams));
   const [selectedRows, setSelectedRows] = useState<ApplicationResponse[]>([]);
 
   const isLoading = state === 'loading';
@@ -253,6 +259,10 @@ const ApplicationList = () => {
                     selectedResults: uniqArray(
                       selectedRows.map((row) => row.result.status),
                     ) as ApplicationResultStatusKeyType[],
+                    refreshList: () => {
+                      refreshApplications();
+                      setSelectedRows([]);
+                    },
                   },
                   isOpen: true,
                 })
@@ -281,10 +291,11 @@ const ApplicationList = () => {
         pagination={
           <Pagination
             pageOptions={pageOptions}
-            selectableSize
-            selectBoxPosition={loadedTableRows.length > 3 ? 'top' : 'bottom'}
+            selectableSize={{
+              selectBoxPosition: loadedTableRows.length > 3 ? 'top' : 'bottom',
+              handleChangeSize,
+            }}
             handleChangePage={handleChangePage}
-            handleChangeSize={handleChangeSize}
           />
         }
       />

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -11,7 +11,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useRecoilStateLoadable, useRecoilValue, useSetRecoilState } from 'recoil';
 import * as api from '@/api';
 import { Button, Pagination, SearchOptionBar, Table, TeamNavigationTabs } from '@/components';
-import { formatDate } from '@/utils';
+import { formatDate, uniqArray } from '@/utils';
 import { PATH, SORT_TYPE } from '@/constants';
 import { $applications, $teamIdByName, ModalKey, $modalByStorage } from '@/store';
 import { useDirty, usePagination } from '@/hooks';
@@ -93,7 +93,8 @@ const columns: TableColumn<ApplicationResponse>[] = [
 ];
 
 const ApplicationList = () => {
-  const handleControlModal = useSetRecoilState($modalByStorage(ModalKey.changeResultModalDialog));
+  const handleSMSModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
+  const handleResultModal = useSetRecoilState($modalByStorage(ModalKey.changeResultModalDialog));
 
   const [searchParams] = useSearchParams();
   const teamName = searchParams.get('team');
@@ -226,18 +227,38 @@ const ApplicationList = () => {
           totalSummaryText: '총 지원인원',
           selectedSummaryText: '명 선택',
           buttons: [
-            <Styled.DisabledButton $size={ButtonSize.xs} shape={ButtonShape.defaultLine}>
-              SMS 발송
-            </Styled.DisabledButton>,
             <Button
               $size={ButtonSize.xs}
               shape={ButtonShape.defaultLine}
               onClick={() =>
-                handleControlModal({
+                handleSMSModal({
+                  key: ModalKey.smsSendModalDialog,
+                  props: {
+                    selectedList: selectedRows.map((row) => row.applicationId),
+                    selectedResults: uniqArray(
+                      selectedRows.map((row) => row.result.status),
+                    ) as ApplicationResultStatusKeyType[],
+                    selectedConfirmStatuses: uniqArray(
+                      selectedRows.map((row) => row.confirmationStatus),
+                    ) as ApplicationConfirmationStatusKeyType[],
+                  },
+                  isOpen: true,
+                })
+              }
+            >
+              SMS 발송
+            </Button>,
+            <Button
+              $size={ButtonSize.xs}
+              shape={ButtonShape.defaultLine}
+              onClick={() =>
+                handleResultModal({
                   key: ModalKey.changeResultModalDialog,
                   props: {
                     selectedList: selectedRows.map((row) => row.applicationId),
-                    selectedResults: [...new Set(selectedRows.map((row) => row.result.status))],
+                    selectedResults: uniqArray(
+                      selectedRows.map((row) => row.result.status),
+                    ) as ApplicationResultStatusKeyType[],
                   },
                   isOpen: true,
                 })

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -241,6 +241,7 @@ const ApplicationList = () => {
                   key: ModalKey.smsSendModalDialog,
                   props: {
                     selectedApplications: selectedRows,
+                    showSummary: true,
                   },
                   isOpen: true,
                 })

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -234,13 +234,7 @@ const ApplicationList = () => {
                 handleSMSModal({
                   key: ModalKey.smsSendModalDialog,
                   props: {
-                    selectedList: selectedRows.map((row) => row.applicationId),
-                    selectedResults: uniqArray(
-                      selectedRows.map((row) => row.result.status),
-                    ) as ApplicationResultStatusKeyType[],
-                    selectedConfirmStatuses: uniqArray(
-                      selectedRows.map((row) => row.confirmationStatus),
-                    ) as ApplicationConfirmationStatusKeyType[],
+                    selectedApplications: selectedRows,
                   },
                   isOpen: true,
                 })

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,3 +1,5 @@
 export const rangeArray = (length: number) => {
   return [...Array(length)].map((_, index) => index + 1);
 };
+
+export const uniqArray = <T>(arr: T[]) => [...new Set(arr)];

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,12 @@
+import { SORT_TYPE } from '@/constants';
+import { ValueOf } from '@/types';
+
+export const sortString = (type: ValueOf<typeof SORT_TYPE>, one: string, another: string) => {
+  const compared = one < another;
+
+  if (type === SORT_TYPE.ASC) {
+    return compared ? -1 : 1;
+  }
+
+  return compared ? 1 : -1;
+};


### PR DESCRIPTION
## 변경사항

- SMS 일괄전송 모달 적용
- Pagination, Table 필요한 부분 리팩토링
  - paging 할 때 url 안건드릴 수 있는 옵션 추가
  - Table 스타일 변경
- 합격 여부 일괄 변경 후 새로고침 하지 않아도 지원서 새로 받아와서 그려주도록 수정

## TODO
모달 내에 Table을 붙히면서 기존에 지원서 내역 페이지에 Table body에 스크롤이 안생기고 height가 auto로 잡히도록 변경되었습니다.
다음 PR에서 지원서 내역 페이지에 Table 스타일 수정을 다룰 예정입니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)