### PR TITLE
인터뷰 결과 발표 이후에 합격 여부 변경을 못하도록 처리

### DIFF
--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -14,7 +14,11 @@ import ApplicationStatusBadge, {
   ApplicationResultStatusKeyType,
   ApplicationResultStatusType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
-import { toUtcWithoutChangingTime, formatDate } from '@/utils/date';
+import {
+  toUtcWithoutChangingTime,
+  formatDate,
+  getRecruitingProgressStatusFromRecruitingPeriod,
+} from '@/utils/date';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import { useOnClickOutSide, useToast } from '@/hooks';
 import { rangeArray, request } from '@/utils';
@@ -269,6 +273,20 @@ const ApplicationPanel = ({
         if (applicationResultStatus !== ApplicationResultStatusInDto.SCREENING_PASSED) {
           delete requestDto.interviewStartedAt;
           delete requestDto.interviewEndedAt;
+        }
+
+        const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(
+          new Date(),
+        );
+
+        if (
+          recruitingProgressStatus === 'PREVIOUS' ||
+          recruitingProgressStatus === 'AFTER-FIRST-SEMINAR'
+        ) {
+          return handleAddToast({
+            type: ToastType.error,
+            message: '변경 기간이 아닙니다.',
+          });
         }
 
         request({

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -66,7 +66,9 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
     [resultStatus],
   );
 
-  const [isShowInterviewSchedule, setIsShowInterviewSchedule] = useState(isScreeningPassed);
+  const [isShowInterviewSchedule, setIsShowInterviewSchedule] = useState(
+    resultStatus === ApplicationResultStatusInDto.SCREENING_PASSED,
+  );
   const [isDatePickerOpened, setIsDatePickerOpened] = useState(false);
   const outerRef = useRef<HTMLDivElement>(null);
   const selectedApplicationResultStatusRef = useRef<HTMLSelectElement>(null);

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -18,6 +18,7 @@ import {
   toUtcWithoutChangingTime,
   formatDate,
   getRecruitingProgressStatusFromRecruitingPeriod,
+  RecruitingProgressStatus,
 } from '@/utils/date';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import { useOnClickOutSide, useToast } from '@/hooks';
@@ -280,8 +281,8 @@ const ApplicationPanel = ({
         );
 
         if (
-          recruitingProgressStatus === 'PREVIOUS' ||
-          recruitingProgressStatus === 'AFTER-FIRST-SEMINAR'
+          recruitingProgressStatus === RecruitingProgressStatus.PREVIOUS ||
+          recruitingProgressStatus === RecruitingProgressStatus.AFTER_FIRST_SEMINAR
         ) {
           return handleAddToast({
             type: ToastType.error,

--- a/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
+++ b/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef } from 'react';
 import { useRecoilCallback } from 'recoil';
 import { useForm } from 'react-hook-form';
-import { request } from '@/utils';
+import { getRecruitingProgressStatusFromRecruitingPeriod, request } from '@/utils';
 import { ModalWrapper, SelectField, TitleWithContent } from '@/components';
 import * as Styled from './ChangeResultModalDialog.styled';
 import * as api from '@/api';
@@ -47,6 +47,20 @@ const ChangeResultModalDialog = ({
   const handleSendSms = useRecoilCallback(
     ({ set }) =>
       async ({ applicationResultStatus }: FormValues) => {
+        const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(
+          new Date(),
+        );
+
+        if (
+          recruitingProgressStatus === 'PREVIOUS' ||
+          recruitingProgressStatus === 'AFTER-FIRST-SEMINAR'
+        ) {
+          return handleAddToast({
+            type: ToastType.error,
+            message: '변경 기간이 아닙니다.',
+          });
+        }
+
         await set($modalByStorage(ModalKey.alertModalDialog), {
           key: ModalKey.alertModalDialog,
           isOpen: true,

--- a/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
+++ b/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo, useRef } from 'react';
 import { useRecoilCallback } from 'recoil';
 import { useForm } from 'react-hook-form';
-import { getRecruitingProgressStatusFromRecruitingPeriod, request } from '@/utils';
+import {
+  getRecruitingProgressStatusFromRecruitingPeriod,
+  RecruitingProgressStatus,
+  request,
+} from '@/utils';
 import { ModalWrapper, SelectField, TitleWithContent } from '@/components';
 import * as Styled from './ChangeResultModalDialog.styled';
 import * as api from '@/api';
@@ -52,8 +56,8 @@ const ChangeResultModalDialog = ({
         );
 
         if (
-          recruitingProgressStatus === 'PREVIOUS' ||
-          recruitingProgressStatus === 'AFTER-FIRST-SEMINAR'
+          recruitingProgressStatus === RecruitingProgressStatus.PREVIOUS ||
+          recruitingProgressStatus === RecruitingProgressStatus.AFTER_FIRST_SEMINAR
         ) {
           return handleAddToast({
             type: ToastType.error,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -16,3 +16,57 @@ export const formatDate = (date: string | Date, format: DateFormat) => {
 export const toUtcWithoutChangingTime = (date: string | Date) => {
   return dayjs(date).utc(true).format().replace('Z', '');
 };
+
+const [
+  RECRUITMENT_START_KST_DATE, // 서류 접수 시작
+  RECRUITMENT_END_KST_DATE, // 서류 접수 종료
+  SCREENING_RESULT_ANNOUNCED_KST_DATE, // 서류 결과 발표
+  INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
+  AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
+] = [
+  dayjs('2022-03-16T00:00:00+09:00'),
+  dayjs('2022-03-29T23:59:59+09:00'),
+  dayjs('2022-04-02T10:00:00+09:00'),
+  dayjs('2022-04-12T10:00:00+09:00'),
+  dayjs('2022-04-16T17:00:00+09:00'),
+];
+
+export type RecruitingProgressStatus =
+  | 'PREVIOUS'
+  | 'IN-RECRUITING'
+  | 'END-RECRUITING'
+  | 'AFTER-SCREENING-ANNOUNCED' // 지원 현황 서류 검토 -> 서류 결과 발표
+  | 'AFTER-INTERVIEWING-ANNOUNCED' // 지원 현황 서류 결과 발표 -> 최종 합격 발표
+  | 'AFTER-FIRST-SEMINAR' // 지원 현황 결과 발표 숨김
+  | 'INVALID';
+
+export const getRecruitingProgressStatusFromRecruitingPeriod = (
+  date: Date,
+): RecruitingProgressStatus => {
+  const currentDate = dayjs(date);
+  if (currentDate < RECRUITMENT_START_KST_DATE) {
+    return 'PREVIOUS';
+  }
+  if (RECRUITMENT_START_KST_DATE <= currentDate && currentDate <= RECRUITMENT_END_KST_DATE) {
+    return 'IN-RECRUITING';
+  }
+  if (RECRUITMENT_END_KST_DATE < currentDate && currentDate < SCREENING_RESULT_ANNOUNCED_KST_DATE) {
+    return 'END-RECRUITING';
+  }
+  if (
+    SCREENING_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
+    currentDate < INTERVIEW_RESULT_ANNOUNCED_KST_DATE
+  ) {
+    return 'AFTER-SCREENING-ANNOUNCED';
+  }
+  if (
+    INTERVIEW_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
+    currentDate < AFTER_FIRST_SEMINAR_JOIN_KST_DATE
+  ) {
+    return 'AFTER-INTERVIEWING-ANNOUNCED';
+  }
+  if (AFTER_FIRST_SEMINAR_JOIN_KST_DATE <= currentDate) {
+    return 'AFTER-FIRST-SEMINAR';
+  }
+  return 'INVALID';
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { ValueOf } from '@/types';
 import 'dayjs/locale/ko';
 
 dayjs.locale('ko');
@@ -31,42 +32,45 @@ const [
   dayjs('2022-04-16T17:00:00+09:00'),
 ];
 
-export type RecruitingProgressStatus =
-  | 'PREVIOUS'
-  | 'IN-RECRUITING'
-  | 'END-RECRUITING'
-  | 'AFTER-SCREENING-ANNOUNCED' // 지원 현황 서류 검토 -> 서류 결과 발표
-  | 'AFTER-INTERVIEWING-ANNOUNCED' // 지원 현황 서류 결과 발표 -> 최종 합격 발표
-  | 'AFTER-FIRST-SEMINAR' // 지원 현황 결과 발표 숨김
-  | 'INVALID';
+export const RecruitingProgressStatus = {
+  PREVIOUS: 'PREVIOUS',
+  IN_RECRUITING: 'IN_RECRUITING',
+  END_RECRUITING: 'END_RECRUITING',
+  AFTER_SCREENING_ANNOUNCED: 'AFTER_SCREENING_ANNOUNCED', // 지원 현황 서류 검토 -> 서류 결과 발표
+  AFTER_INTERVIEWING_ANNOUNCED: 'AFTER_INTERVIEWING_ANNOUNCED', // 지원 현황 서류 결과 발표 -> 최종 합격 발표
+  AFTER_FIRST_SEMINAR: 'AFTER_FIRST_SEMINAR', // 지원 현황 결과 발표 숨김
+  INVALID: 'INVALID',
+} as const;
+
+export type RecruitingProgressStatusValueType = ValueOf<typeof RecruitingProgressStatus>;
 
 export const getRecruitingProgressStatusFromRecruitingPeriod = (
   date: Date,
-): RecruitingProgressStatus => {
+): RecruitingProgressStatusValueType => {
   const currentDate = dayjs(date);
   if (currentDate < RECRUITMENT_START_KST_DATE) {
-    return 'PREVIOUS';
+    return RecruitingProgressStatus.PREVIOUS;
   }
   if (RECRUITMENT_START_KST_DATE <= currentDate && currentDate <= RECRUITMENT_END_KST_DATE) {
-    return 'IN-RECRUITING';
+    return RecruitingProgressStatus.IN_RECRUITING;
   }
   if (RECRUITMENT_END_KST_DATE < currentDate && currentDate < SCREENING_RESULT_ANNOUNCED_KST_DATE) {
-    return 'END-RECRUITING';
+    return RecruitingProgressStatus.END_RECRUITING;
   }
   if (
     SCREENING_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
     currentDate < INTERVIEW_RESULT_ANNOUNCED_KST_DATE
   ) {
-    return 'AFTER-SCREENING-ANNOUNCED';
+    return RecruitingProgressStatus.AFTER_SCREENING_ANNOUNCED;
   }
   if (
     INTERVIEW_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
     currentDate < AFTER_FIRST_SEMINAR_JOIN_KST_DATE
   ) {
-    return 'AFTER-INTERVIEWING-ANNOUNCED';
+    return RecruitingProgressStatus.AFTER_INTERVIEWING_ANNOUNCED;
   }
   if (AFTER_FIRST_SEMINAR_JOIN_KST_DATE <= currentDate) {
-    return 'AFTER-FIRST-SEMINAR';
+    return RecruitingProgressStatus.AFTER_FIRST_SEMINAR;
   }
-  return 'INVALID';
+  return RecruitingProgressStatus.INVALID;
 };


### PR DESCRIPTION
## 변경사항

- 수정 클릭시 SCREENING_PASSED 일 경우에만 날짜 선택이 나오도록 함
- 인터뷰 결과 발표 이후에 합격 여부 변경을 못하도록 처리
  - 케이스를 세밀하게 나누려고 했으나 오히려 운영진이 선택을 실수할 경우 문제가 될 것 같아 인터뷰 결과 발표  이후에만 변경 불가하도록 처리

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)