### PR TITLE
QA 3차 대응 (v0.4.0) - dididy

### DIFF
--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -129,7 +129,7 @@ const ControlArea = ({ confirmationStatus, resultStatus, interviewDate }: Contro
     );
 
     if (isScreeningPassed) {
-      return resultOption.slice(1, 6);
+      return resultOption.slice(1, resultOption.length);
     }
 
     return resultOption.slice(0, 4);

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import dayjs, { Dayjs } from 'dayjs';
 import { useRecoilCallback } from 'recoil';
 import utc from 'dayjs/plugin/utc';
+import { useLocation } from 'react-router-dom';
 import { Button, DatePicker, Select, SelectField } from '@/components';
 import * as Styled from './ApplicationPanel.styled';
 import { ButtonShape, ButtonSize } from '@/components/common/Button/Button.component';
@@ -26,10 +27,11 @@ import { rangeArray, request } from '@/utils';
 import * as api from '@/api';
 import {
   ApplicationConfirmationStatusInDto,
+  ApplicationRequest,
   ApplicationResultStatusInDto,
   ApplicationUpdateResultByIdRequest,
 } from '@/types';
-import { $applicationById } from '@/store';
+import { $applicationById, $applications } from '@/store';
 import { ToastType } from '@/styles';
 
 dayjs.extend(utc);
@@ -246,6 +248,7 @@ const ApplicationPanel = ({
   applicationId,
   ...restProps
 }: ApplicationPanelProps) => {
+  const { state } = useLocation();
   const { handleAddToast } = useToast();
   const methods = useForm<FormValues>({
     defaultValues: {
@@ -297,6 +300,7 @@ const ApplicationPanel = ({
           errorHandler: handleAddToast,
           onSuccess: async () => {
             await refresh($applicationById({ applicationId }));
+            await refresh($applications(state as ApplicationRequest));
             methods.setValue('isEdit', false);
             handleAddToast({
               type: ToastType.success,

--- a/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
+++ b/src/components/common/SmsSendModalDialog/SmsSendModalDialog.component.tsx
@@ -125,6 +125,7 @@ const SmsSendModalDialog = ({
       },
     },
     handleCloseModal: handleRemoveCurrentModal,
+    closeOnClickOverlay: false,
   };
 
   return (

--- a/src/components/common/Table/Table.component.tsx
+++ b/src/components/common/Table/Table.component.tsx
@@ -8,7 +8,7 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { NestedKeyOf, ValueOf } from '@/types';
+import { ApplicationRequest, NestedKeyOf, ValueOf } from '@/types';
 import { getOwnValueByKey, isArray, isSameObject, request } from '@/utils';
 import { colors } from '@/styles';
 import QuestionFile from '@/assets/svg/question-file-72.svg';
@@ -65,6 +65,7 @@ export interface TableProps<T extends object> {
     buttons?: ReactNode[];
   };
   pagination?: ReactNode;
+  applicationParams?: ApplicationRequest;
 }
 
 interface TableSupportBarProps {
@@ -249,6 +250,7 @@ const Table = <T extends object>({
   sortOptions,
   supportBar: { totalCount, totalSummaryText, selectedSummaryText, buttons: supportButtons },
   pagination,
+  applicationParams,
 }: TableProps<T>) => {
   const navigate = useNavigate();
   const { handleAddToast } = useToast();
@@ -378,7 +380,7 @@ const Table = <T extends object>({
                               });
                             },
                             onSuccess: async () => {
-                              navigate(`${PATH.APPLICATION}/${id}`);
+                              navigate(`${PATH.APPLICATION}/${id}`, { state: applicationParams });
                             },
                           });
                         };

--- a/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component.tsx
+++ b/src/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component.tsx
@@ -107,6 +107,7 @@ const SmsSendDetailInfoModalDialog = ({ sms }: SmsSendDetailInfoModalDialogProps
     },
     handleCloseModal: handleRemoveCurrentModal,
     isContentScroll: false,
+    closeOnClickOverlay: false,
   };
 
   return (

--- a/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
+++ b/src/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component.tsx
@@ -71,6 +71,7 @@ const SmsSendDetailListModalDialog = ({
     },
     handleCloseModal: handleRemoveCurrentModal,
     isContentScroll: false,
+    closeOnClickOverlay: false,
   };
 
   return (

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -354,6 +354,7 @@ const ApplicationList = () => {
             handleChangePage={handleChangePage}
           />
         }
+        applicationParams={applicationParams}
       />
       <BottomCTA
         boundaries={{


### PR DESCRIPTION
## 변경사항

- [상세페이지 합격여부] 최종합격 선택지가 빠져있는 이슈 해결
- 지원서가 선택되었을때도 SMS 발송, 합격 여부 변경 cursor가 not-allowed로 되어있는 이슈 해결
- SMS 발송 모달 딤 영역 클릭시 닫히는 동작 제거
- 상세페이지에서 합격 여부 변경시 테이블에 반영 안되는 이슈 임시 해결 #170 

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)