### PR TITLE
QA 12차 대응 (v0.4.0) - mango906

### DIFF
--- a/src/components/ApplicationForm/ApplicationFormSection/ApplicationFormSection.component.tsx
+++ b/src/components/ApplicationForm/ApplicationFormSection/ApplicationFormSection.component.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { BackButton } from '@/components';
 import * as Styled from './ApplicationFormSection.styled';
 import { PATH } from '@/constants';
+import { useHistory } from '@/hooks';
 
 interface ApplicationFormSectionProps {
   headline: string;
 }
 
 const ApplicationFormSection = ({ headline }: ApplicationFormSectionProps) => {
-  const navigate = useNavigate();
+  const { handleGoBack } = useHistory();
 
   return (
     <section>
-      <BackButton label="목록 돌아가기" onClick={() => navigate(PATH.APPLICATION_FORM)} />
+      <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.APPLICATION_FORM)} />
       <Styled.Headline>{headline}</Styled.Headline>
     </section>
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as useConvertToXlsx } from './useConvertToXlsx';
 export { default as useBottomCTA } from './useBottomCTA';
 export { default as useWindowScroll } from './useWindowScroll';
 export { default as useConvertTextToLink } from './useConvertTextToLink';
+export { default as useHistory } from './useHistory';

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,0 +1,38 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+type HistoryLocationFromState = { from: string } | undefined;
+
+const useHistory = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { from } = (location.state as HistoryLocationFromState) ?? {};
+
+  const handleNavigate = (to: string) => {
+    navigate(to, {
+      state: {
+        from: location.pathname,
+      },
+    });
+  };
+
+  const handleGoBack = (defaultPath?: string) => {
+    if (from) {
+      navigate(from);
+      return;
+    }
+
+    if (defaultPath) {
+      navigate(defaultPath);
+      return;
+    }
+
+    navigate(-1);
+  };
+
+  return {
+    handleNavigate,
+    handleGoBack,
+  };
+};
+
+export default useHistory;

--- a/src/pages/ApplicationDetailView/ApplicationDetailView.page.tsx
+++ b/src/pages/ApplicationDetailView/ApplicationDetailView.page.tsx
@@ -15,6 +15,7 @@ import { $applicationById } from '@/store';
 import { ApplicationByIdResponseData, Question } from '@/types';
 import { PATH } from '@/constants';
 import * as api from '@/api';
+import { useHistory } from '@/hooks';
 
 const ApplicationDetailView = () => {
   const navigate = useNavigate();
@@ -22,6 +23,7 @@ const ApplicationDetailView = () => {
   const data = useRecoilValue<ApplicationByIdResponseData>(
     $applicationById({ applicationId: id as string }),
   );
+  const { handleGoBack } = useHistory();
 
   useEffect(() => {
     (async () => {
@@ -41,7 +43,7 @@ const ApplicationDetailView = () => {
   return (
     <Styled.ApplicationDetailViewPage>
       <section>
-        <BackButton label="목록 돌아가기" onClick={() => navigate(PATH.APPLICATION)} />
+        <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.APPLICATION)} />
         <Styled.Headline>지원설문지 상세</Styled.Headline>
       </section>
       <div>

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useRecoilStateLoadable, useRecoilValue } from 'recoil';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import Preview from '@/assets/svg/preview-20.svg';
 
@@ -41,57 +41,6 @@ const ApplicationFormPreview = ({ questions }: { questions: Question[] }) => {
   );
 };
 
-const columns: TableColumn<ApplicationFormResponse>[] = [
-  {
-    title: '플랫폼',
-    accessor: 'team.name',
-    widthRatio: '9%',
-  },
-  {
-    title: '지원서 설문지 문서명',
-    accessor: 'name',
-    idAccessor: 'applicationFormId',
-    widthRatio: '28%',
-    renderCustomCell: (cellValue, id) => (
-      <Styled.FormTitleWrapper title={cellValue as string}>
-        <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
-        <Styled.TitleLink to={`${PATH.APPLICATION_FORM}/${id}`} />
-      </Styled.FormTitleWrapper>
-    ),
-  },
-  {
-    title: '작성자',
-    accessor: 'createdBy',
-    widthRatio: '14%',
-    renderCustomCell: (cellValue) => {
-      const [team, role] = (cellValue as string).split('_') as [TeamType, RoleType];
-      return (
-        <Styled.CustomUserProfile>
-          <UserProfile team={team} role={role} showBackground={false} />
-        </Styled.CustomUserProfile>
-      );
-    },
-  },
-  {
-    title: '작성일시',
-    accessor: 'createdAt',
-    widthRatio: '21%',
-    renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
-  },
-  {
-    title: '수정일시',
-    accessor: 'updatedAt',
-    widthRatio: '21%',
-    renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
-  },
-  {
-    title: '미리보기',
-    accessor: 'questions',
-    renderCustomCell: (cellValue) => <ApplicationFormPreview questions={cellValue as Question[]} />,
-    widthRatio: '7%',
-  },
-];
-
 const ApplicationFormList = () => {
   const [searchParams] = useSearchParams();
   const teamName = searchParams.get('team');
@@ -101,6 +50,8 @@ const ApplicationFormList = () => {
   const size = searchParams.get('size') || '20';
 
   const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
+
+  const { pathname, search } = useLocation();
 
   const [sortTypes, setSortTypes] = useState<SortType<ApplicationFormResponse>[]>([
     { accessor: 'team.name', type: SORT_TYPE.DEFAULT },
@@ -149,6 +100,62 @@ const ApplicationFormList = () => {
     e.preventDefault();
     setSearchWord({ value: e.target.searchWord.value });
   };
+
+  const columns: TableColumn<ApplicationFormResponse>[] = [
+    {
+      title: '플랫폼',
+      accessor: 'team.name',
+      widthRatio: '9%',
+    },
+    {
+      title: '지원서 설문지 문서명',
+      accessor: 'name',
+      idAccessor: 'applicationFormId',
+      widthRatio: '28%',
+      renderCustomCell: (cellValue, id) => (
+        <Styled.FormTitleWrapper title={cellValue as string}>
+          <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
+          <Styled.TitleLink
+            to={`${PATH.APPLICATION_FORM}/${id}`}
+            state={{ from: `${pathname}${search}` }}
+          />
+        </Styled.FormTitleWrapper>
+      ),
+    },
+    {
+      title: '작성자',
+      accessor: 'createdBy',
+      widthRatio: '14%',
+      renderCustomCell: (cellValue) => {
+        const [team, role] = (cellValue as string).split('_') as [TeamType, RoleType];
+        return (
+          <Styled.CustomUserProfile>
+            <UserProfile team={team} role={role} showBackground={false} />
+          </Styled.CustomUserProfile>
+        );
+      },
+    },
+    {
+      title: '작성일시',
+      accessor: 'createdAt',
+      widthRatio: '21%',
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+    },
+    {
+      title: '수정일시',
+      accessor: 'updatedAt',
+      widthRatio: '21%',
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+    },
+    {
+      title: '미리보기',
+      accessor: 'questions',
+      renderCustomCell: (cellValue) => (
+        <ApplicationFormPreview questions={cellValue as Question[]} />
+      ),
+      widthRatio: '7%',
+    },
+  ];
 
   useEffect(() => {
     if (!isLoading) {

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
   FormEvent,
 } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { writeFileXLSX } from 'xlsx';
 import {
   useRecoilStateLoadable,
@@ -42,77 +42,11 @@ import { ApplicationFilterValuesType } from '@/components/common/SearchOptionBar
 
 const APPLICATION_EXTRA_SIZE = 100;
 
-const columns: TableColumn<ApplicationResponse>[] = [
-  {
-    title: '이름',
-    accessor: 'applicant.name',
-    idAccessor: 'applicationId',
-    widthRatio: '10%',
-    renderCustomCell: (cellValue, id, handleClickLink, applicationParams) => (
-      <Styled.FormTitleWrapper title={cellValue as string}>
-        <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
-        {handleClickLink ? (
-          <Styled.TitleButton type="button" onClick={handleClickLink} />
-        ) : (
-          <Styled.TitleLink to={`${PATH.APPLICATION}/${id}`} state={applicationParams} />
-        )}
-      </Styled.FormTitleWrapper>
-    ),
-  },
-  {
-    title: '전화번호',
-    accessor: 'applicant.phoneNumber',
-    widthRatio: '14%',
-  },
-  {
-    title: '지원플랫폼',
-    accessor: 'team.name',
-    widthRatio: '8%',
-  },
-  {
-    title: '지원일시',
-    accessor: 'submittedAt',
-    widthRatio: '21%',
-    renderCustomCell: (cellValue) =>
-      cellValue ? formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분') : '-',
-  },
-  {
-    title: '면접일시',
-    accessor: 'result.interviewStartedAt',
-    widthRatio: '21%',
-    renderCustomCell: (cellValue) =>
-      cellValue ? formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분') : '-',
-  },
-  {
-    title: '사용자확인여부',
-    accessor: 'confirmationStatus',
-    widthRatio: '13%',
-    renderCustomCell: (cellValue) => (
-      <Styled.Center>
-        <ApplicationStatusBadge
-          text={ApplicationConfirmationStatus[cellValue as ApplicationConfirmationStatusKeyType]}
-        />
-      </Styled.Center>
-    ),
-  },
-  {
-    title: '합격여부',
-    accessor: 'result.status',
-    widthRatio: '13%',
-    renderCustomCell: (cellValue) => (
-      <Styled.Center>
-        <ApplicationStatusBadge
-          text={ApplicationResultStatus[cellValue as ApplicationResultStatusKeyType]}
-        />
-      </Styled.Center>
-    ),
-  },
-];
-
 const ApplicationList = () => {
   const handleSMSModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
   const handleResultModal = useSetRecoilState($modalByStorage(ModalKey.changeResultModalDialog));
 
+  const { pathname, search } = useLocation();
   const [searchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
@@ -239,6 +173,76 @@ const ApplicationList = () => {
     },
     [tableRows.page?.totalCount, teamId],
   );
+
+  const columns: TableColumn<ApplicationResponse>[] = [
+    {
+      title: '이름',
+      accessor: 'applicant.name',
+      idAccessor: 'applicationId',
+      widthRatio: '10%',
+      renderCustomCell: (cellValue, id, handleClickLink, applicationParamStates) => (
+        <Styled.FormTitleWrapper title={cellValue as string}>
+          <Styled.FormTitle>{cellValue as string}</Styled.FormTitle>
+          {handleClickLink ? (
+            <Styled.TitleButton type="button" onClick={handleClickLink} />
+          ) : (
+            <Styled.TitleLink
+              to={`${PATH.APPLICATION}/${id}`}
+              state={{ ...applicationParamStates, from: `${pathname}${search}` }}
+            />
+          )}
+        </Styled.FormTitleWrapper>
+      ),
+    },
+    {
+      title: '전화번호',
+      accessor: 'applicant.phoneNumber',
+      widthRatio: '14%',
+    },
+    {
+      title: '지원플랫폼',
+      accessor: 'team.name',
+      widthRatio: '8%',
+    },
+    {
+      title: '지원일시',
+      accessor: 'submittedAt',
+      widthRatio: '21%',
+      renderCustomCell: (cellValue) =>
+        cellValue ? formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분') : '-',
+    },
+    {
+      title: '면접일시',
+      accessor: 'result.interviewStartedAt',
+      widthRatio: '21%',
+      renderCustomCell: (cellValue) =>
+        cellValue ? formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분') : '-',
+    },
+    {
+      title: '사용자확인여부',
+      accessor: 'confirmationStatus',
+      widthRatio: '13%',
+      renderCustomCell: (cellValue) => (
+        <Styled.Center>
+          <ApplicationStatusBadge
+            text={ApplicationConfirmationStatus[cellValue as ApplicationConfirmationStatusKeyType]}
+          />
+        </Styled.Center>
+      ),
+    },
+    {
+      title: '합격여부',
+      accessor: 'result.status',
+      widthRatio: '13%',
+      renderCustomCell: (cellValue) => (
+        <Styled.Center>
+          <ApplicationStatusBadge
+            text={ApplicationResultStatus[cellValue as ApplicationResultStatusKeyType]}
+          />
+        </Styled.Center>
+      ),
+    },
+  ];
 
   useEffect(() => {
     if (!isLoading) {


### PR DESCRIPTION
## 변경사항

- useHistory 커스텀 훅 추가
  - 이전 path를 가져올 방법이 push 할떄 state로 넣어주는 방법밖에 없는거 같아서, state로 넣어주는 push 함수와 state 체크해서 뒤로가기 해주는 goBack 함수 생성
- 지원서 설문 상세에서 이전 path를 가지고 있을 경우 이전 path로 가고 (query string 유지), 없다면 default로 설정한 url로 이동하도록 수정
  - react-router v6로 넘어오면서 `useLocation`에 사용되던 제네릭이 삭제된거 같음.... 그래서 쩔수 없이 assertion했음
  - https://github.com/reach/router/issues/414#issuecomment-1003613775

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)