### PR TITLE
useConvertToXlsx 에서 isLoading에 따라 useEffect이 실행되도록 한다

### DIFF
--- a/src/hooks/useConvertToXlsx.ts
+++ b/src/hooks/useConvertToXlsx.ts
@@ -4,17 +4,18 @@ import { utils, WorkBook } from 'xlsx';
 interface UseExportXlsxProps<T> {
   workSheet: T[];
   teamName: string;
+  isLoading: boolean;
 }
 
-const useConvertToXlsx = <T>({ workSheet, teamName }: UseExportXlsxProps<T>) => {
+const useConvertToXlsx = <T>({ workSheet, teamName, isLoading }: UseExportXlsxProps<T>) => {
   const workBookRef = useRef<WorkBook>(utils.book_new());
   useEffect(() => {
     if (workSheet) {
       workBookRef.current = utils.book_new();
       const sheet = utils.json_to_sheet(workSheet);
-      utils.book_append_sheet(workBookRef.current, sheet, teamName || '전체');
+      utils.book_append_sheet(workBookRef.current, sheet, teamName);
     }
-  }, [teamName, workSheet]);
+  }, [teamName, workSheet, isLoading]);
 
   return { workBook: workBookRef.current };
 };

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -206,6 +206,7 @@ const ApplicationList = () => {
       합격여부: ApplicationResultStatus[each.result.status],
     })),
     teamName: teamName || '전체',
+    isLoading,
   });
 
   const { pageOptions, handleChangePage, handleChangeSize } = usePagination({


### PR DESCRIPTION
## 변경사항

- 상용에서 처음 지원자 리스트 진입시 xlsx 파일 다운 안되는 이슈 해결

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)