### PR TITLE
상세페이지에서도 navigation active 되도록 수정

### DIFF
--- a/src/components/common/Navigation/Navigation.component.tsx
+++ b/src/components/common/Navigation/Navigation.component.tsx
@@ -30,17 +30,21 @@ const Navigation = ({ size, inActiveColor, items, showBottomBorder = true }: Nav
 
   return (
     <Styled.NavigationContainer showBottomBorder={showBottomBorder}>
-      {items.map((item) => (
-        <Styled.NavigationItem
-          key={item.to}
-          size={size}
-          to={item.to}
-          inActiveColor={inActiveColor}
-          active={pathname === item.to}
-        >
-          {item.label}
-        </Styled.NavigationItem>
-      ))}
+      {items.map((item) => {
+        const isActive = pathname.split('/').some((pathNameItem) => `/${pathNameItem}` === item.to);
+
+        return (
+          <Styled.NavigationItem
+            key={item.to}
+            size={size}
+            to={item.to}
+            inActiveColor={inActiveColor}
+            active={isActive}
+          >
+            {item.label}
+          </Styled.NavigationItem>
+        );
+      })}
     </Styled.NavigationContainer>
   );
 };


### PR DESCRIPTION
## 변경사항

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/38802280/175774551-68c2bd8a-0f57-4537-9f78-928ab89a80aa.png">

기존에는 pathname이랑 절대적으로 (?) 비교해서 상세 페이지나 수정 페이지에서는 navigation 이 active되어 있지 않는 문제가 있어서 수정하였습니당

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->


- 버그 수정


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)