### PR TITLE
지원서 상세에서 뒤로가기할 때 필터 유지되도록 변경

### DIFF
--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -1,4 +1,5 @@
-import React, { Dispatch, SetStateAction, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Input, Select } from '@/components';
 import { ButtonSize, ButtonShape } from '@/components/common/Button/Button.component';
 import * as Styled from './SearchOptionBar.styled';
@@ -18,9 +19,8 @@ export interface ApplicationFilterValuesType {
 interface SearchOptionBarProps {
   placeholder?: string;
   searchWord: { value: string };
+  showFilterValues?: boolean;
   handleSubmit: React.FormEventHandler<HTMLFormElement>;
-  filterValues?: ApplicationFilterValuesType;
-  setFilterValues?: Dispatch<SetStateAction<ApplicationFilterValuesType>>;
 }
 
 const DEFAULT = { label: '전체', value: '' };
@@ -28,17 +28,31 @@ const DEFAULT = { label: '전체', value: '' };
 const SearchOptionBar = ({
   placeholder,
   searchWord,
+  showFilterValues = true,
   handleSubmit,
-  filterValues,
-  setFilterValues,
 }: SearchOptionBarProps) => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const ref = useRef<HTMLInputElement>(null);
+
+  const [filterValues, setFilterValues] = useState<ApplicationFilterValuesType>({
+    confirmStatus: { label: '', value: '' },
+    resultStatus: { label: '', value: '' },
+  });
 
   const handleApplicationConfirmStatus = (option: SelectOption) => {
     setFilterValues?.((prev) => ({
       ...prev,
       confirmStatus: option,
     }));
+
+    if (option.value === DEFAULT.value) {
+      searchParams.delete('confirmStatus');
+      setSearchParams(searchParams);
+      return;
+    }
+
+    searchParams.set('confirmStatus', option.value);
+    setSearchParams(searchParams);
   };
 
   const handleApplicationResultStatus = (option: SelectOption) => {
@@ -46,6 +60,15 @@ const SearchOptionBar = ({
       ...prev,
       resultStatus: option,
     }));
+
+    if (option.value === DEFAULT.value) {
+      searchParams.delete('confirmStatus');
+      setSearchParams(searchParams);
+      return;
+    }
+
+    searchParams.set('resultStatus', option.value);
+    setSearchParams(searchParams);
   };
 
   useLayoutEffect(() => {
@@ -90,7 +113,7 @@ const SearchOptionBar = ({
 
   return (
     <Styled.BarContainer onSubmit={handleSubmit}>
-      {filterValues && (
+      {showFilterValues && (
         <Styled.SelectContainer>
           <div>
             <div>합격여부</div>

--- a/src/hooks/useHistory.test.ts
+++ b/src/hooks/useHistory.test.ts
@@ -53,7 +53,7 @@ describe('useHistory', () => {
     expect(mockNavigate).toBeCalledWith(-1);
   });
 
-  it('clearQueryString값이 false라면 from값에 쿼리스트링도 함께 저장된다.', () => {
+  it('shouldClearQueryString값이 false라면 from값에 쿼리스트링도 함께 저장된다.', () => {
     // Given
     const from = '/from';
     const queryString = '?queryString=queryString';

--- a/src/hooks/useHistory.test.ts
+++ b/src/hooks/useHistory.test.ts
@@ -1,0 +1,76 @@
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useHistory from './useHistory';
+
+const mockNavigate = jest.fn();
+
+const mockUseLocation = jest.fn().mockImplementation(() => ({ state: {} }));
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => mockUseLocation(),
+  useNavigate: jest.fn().mockImplementation(() => mockNavigate),
+}));
+
+describe('useHistory', () => {
+  it('from 값이 존재한다면 뒤로가기 클릭 시 from으로 이동한다', () => {
+    // Given
+    const from = 'from';
+    mockUseLocation.mockReturnValueOnce({
+      state: {
+        from,
+      },
+    });
+
+    // When
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.handleGoBack());
+
+    // Then
+    expect(mockNavigate).toBeCalledWith(from);
+  });
+
+  it('from 값이 존재하지 않고 defaultPath가 있다면 defaultPath로 이동한다', () => {
+    // Given
+    const defaultPath = 'default-path';
+
+    // When
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.handleGoBack(defaultPath));
+
+    // Then
+    expect(mockNavigate).toBeCalledWith(defaultPath);
+  });
+
+  it('from 값과 defaultPath값 모두 존재하지 않는다면 뒤로 이동한다', () => {
+    // Given
+
+    // When
+    const { result } = renderHook(() => useHistory());
+    act(() => result.current.handleGoBack());
+
+    // Then
+    expect(mockNavigate).toBeCalledWith(-1);
+  });
+
+  it('clearQueryString값이 false라면 from값에 쿼리스트링도 함께 저장된다.', () => {
+    // Given
+    const from = '/from';
+    const queryString = '?queryString=queryString';
+    const fromWithQueryString = `${from}${queryString}`;
+    const to = '/to';
+
+    mockUseLocation.mockReturnValueOnce({
+      pathname: from,
+      search: queryString,
+    });
+
+    // When
+    const { result } = renderHook(() => useHistory(false));
+    act(() => result.current.handleNavigate(to));
+
+    // Then
+
+    expect(mockNavigate).toBeCalledWith(to, { state: { from: fromWithQueryString } });
+  });
+});

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -2,15 +2,20 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 type HistoryLocationFromState = { from: string } | undefined;
 
-const useHistory = () => {
+const useHistory = (clearQueryString = true) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { search } = location ?? {};
   const { from } = (location.state as HistoryLocationFromState) ?? {};
 
   const handleNavigate = (to: string) => {
+    const currentPath = location.pathname;
+    const currentPathWithQueryString = `${location.pathname}${search}`;
+    const fromPath = clearQueryString ? currentPath : currentPathWithQueryString;
+
     navigate(to, {
       state: {
-        from: location.pathname,
+        from: fromPath,
       },
     });
   };

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -10,7 +10,7 @@ const useHistory = (clearQueryString = true) => {
 
   const handleNavigate = (to: string) => {
     const currentPath = location.pathname;
-    const currentPathWithQueryString = `${location.pathname}${search}`;
+    const currentPathWithQueryString = `${currentPath}${search}`;
     const fromPath = clearQueryString ? currentPath : currentPathWithQueryString;
 
     navigate(to, {

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 type HistoryLocationFromState = { from: string } | undefined;
 
-const useHistory = (clearQueryString = true) => {
+const useHistory = (shouldClearQueryString = true) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { search } = location ?? {};
@@ -11,7 +11,7 @@ const useHistory = (clearQueryString = true) => {
   const handleNavigate = (to: string) => {
     const currentPath = location.pathname;
     const currentPathWithQueryString = `${currentPath}${search}`;
-    const fromPath = clearQueryString ? currentPath : currentPathWithQueryString;
+    const fromPath = shouldClearQueryString ? currentPath : currentPathWithQueryString;
 
     navigate(to, {
       state: {

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useRecoilStateLoadable, useRecoilValue } from 'recoil';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
@@ -42,14 +42,13 @@ const ApplicationFormPreview = ({ questions }: { questions: Question[] }) => {
 };
 
 const ApplicationFormList = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
-
-  const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
+  const searchWord = searchParams.get('searchWord') || '';
 
   const { pathname, search } = useLocation();
 
@@ -72,7 +71,7 @@ const ApplicationFormList = () => {
       page: parseInt(page, 10) - 1,
       size: parseInt(size, 10),
       teamId: parseInt(teamId, 10) || undefined,
-      searchWord: searchWord.value,
+      searchWord,
       sort: sortParam,
     }),
     [page, size, teamId, searchWord, sortParam],
@@ -93,13 +92,6 @@ const ApplicationFormList = () => {
   });
 
   const { makeDirty, isDirty } = useDirty(1);
-
-  const handleSubmit = (
-    e: { target: { searchWord: { value: string } } } & FormEvent<HTMLFormElement>,
-  ) => {
-    e.preventDefault();
-    setSearchWord({ value: e.target.searchWord.value });
-  };
 
   const columns: TableColumn<ApplicationFormResponse>[] = [
     {
@@ -167,7 +159,8 @@ const ApplicationFormList = () => {
   }, [isLoading, tableRows]);
 
   useEffect(() => {
-    setSearchWord({ value: '' });
+    searchParams.delete('searchWord');
+    setSearchParams(searchParams);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
@@ -183,12 +176,7 @@ const ApplicationFormList = () => {
       <Styled.Heading>지원서 설문지 내역</Styled.Heading>
       <Styled.StickyContainer>
         <TeamNavigationTabs />
-        <SearchOptionBar
-          placeholder="지원서 설문지 문서명 검색"
-          searchWord={searchWord}
-          showFilterValues={false}
-          handleSubmit={handleSubmit}
-        />
+        <SearchOptionBar placeholder="지원서 설문지 문서명 검색" showFilterValues={false} />
       </Styled.StickyContainer>
       <Table
         prefix="application-form"

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -186,6 +186,7 @@ const ApplicationFormList = () => {
         <SearchOptionBar
           placeholder="지원서 설문지 문서명 검색"
           searchWord={searchWord}
+          showFilterValues={false}
           handleSubmit={handleSubmit}
         />
       </Styled.StickyContainer>

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -37,7 +37,6 @@ import ApplicationStatusBadge, {
   ApplicationResultStatus,
   ApplicationResultStatusKeyType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
-import { ApplicationFilterValuesType } from '@/components/common/SearchOptionBar/SearchOptionBar.component';
 import * as Styled from './ApplicationList.styled';
 
 const APPLICATION_EXTRA_SIZE = 100;
@@ -62,12 +61,10 @@ const ApplicationList = () => {
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
+  const confirmStatus = searchParams.get('confirmStatus') || '';
+  const resultStatus = searchParams.get('resultStatus') || '';
 
   const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
-  const [filterValues, setFilterValues] = useState<ApplicationFilterValuesType>({
-    confirmStatus: { label: '', value: '' },
-    resultStatus: { label: '', value: '' },
-  });
 
   const [sortTypes, setSortTypes] = useState<SortType<ApplicationResponse>[]>([
     { accessor: 'applicant.name', type: SORT_TYPE.DEFAULT },
@@ -95,12 +92,12 @@ const ApplicationList = () => {
       size: parseInt(size, 10),
       teamId: parseInt(teamId, 10) || undefined,
       searchWord: searchWord.value,
-      confirmStatus: filterValues?.confirmStatus?.value,
-      resultStatus: filterValues?.resultStatus?.value,
+      confirmStatus,
+      resultStatus,
       sort: sortParam,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [page, size, teamId, searchWord, sortParam, filterValues],
+    [page, size, teamId, searchWord, sortParam, confirmStatus, resultStatus],
   );
 
   const [totalCount, setTotalCount] = useState(0);
@@ -266,8 +263,6 @@ const ApplicationList = () => {
         <TeamNavigationTabs />
         <SearchOptionBar
           placeholder="이름, 전화번호 검색"
-          filterValues={filterValues}
-          setFilterValues={setFilterValues}
           searchWord={searchWord}
           handleSubmit={handleSearch}
         />

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useMemo,
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useCallback,
-  FormEvent,
-} from 'react';
+import React, { useMemo, useState, useEffect, useLayoutEffect, useCallback } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { writeFileXLSX } from 'xlsx';
 import {
@@ -46,7 +39,7 @@ const ApplicationList = () => {
   const handleResultModal = useSetRecoilState($modalByStorage(ModalKey.changeResultModalDialog));
 
   const { pathname, search } = useLocation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
   const myTeamName = useRecoilValue($profile)[0];
@@ -63,8 +56,7 @@ const ApplicationList = () => {
   const size = searchParams.get('size') || '20';
   const confirmStatus = searchParams.get('confirmStatus') || '';
   const resultStatus = searchParams.get('resultStatus') || '';
-
-  const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
+  const searchWord = searchParams.get('searchWord') || '';
 
   const [sortTypes, setSortTypes] = useState<SortType<ApplicationResponse>[]>([
     { accessor: 'applicant.name', type: SORT_TYPE.DEFAULT },
@@ -91,7 +83,7 @@ const ApplicationList = () => {
       page: parseInt(page, 10) - 1,
       size: parseInt(size, 10),
       teamId: parseInt(teamId, 10) || undefined,
-      searchWord: searchWord.value,
+      searchWord,
       confirmStatus,
       resultStatus,
       sort: sortParam,
@@ -138,13 +130,6 @@ const ApplicationList = () => {
   });
 
   const { makeDirty, isDirty } = useDirty(1);
-
-  const handleSearch = (
-    e: { target: { searchWord: { value: string } } } & FormEvent<HTMLFormElement>,
-  ) => {
-    e.preventDefault();
-    setSearchWord({ value: e.target.searchWord.value });
-  };
 
   const handleSelectAll = useCallback(
     async (checkedValue) => {
@@ -245,7 +230,9 @@ const ApplicationList = () => {
   }, [isLoading, tableRows]);
 
   useEffect(() => {
-    setSearchWord({ value: '' });
+    searchParams.delete('searchKeyword');
+    setSearchParams(searchParams);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
@@ -261,11 +248,7 @@ const ApplicationList = () => {
       <Styled.Heading>지원서 내역</Styled.Heading>
       <Styled.StickyContainer>
         <TeamNavigationTabs />
-        <SearchOptionBar
-          placeholder="이름, 전화번호 검색"
-          searchWord={searchWord}
-          handleSubmit={handleSearch}
-        />
+        <SearchOptionBar placeholder="이름, 전화번호 검색" />
       </Styled.StickyContainer>
       <Table
         prefix="application"

--- a/src/pages/SmsSendingList/SmsSendingList.page.tsx
+++ b/src/pages/SmsSendingList/SmsSendingList.page.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useRecoilCallback, useRecoilStateLoadable } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
 
@@ -87,8 +87,7 @@ const ApplicationFormList = () => {
   const [searchParams] = useSearchParams();
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
-
-  const [searchWord, setSearchWord] = useState<{ value: string }>({ value: '' });
+  const searchWord = searchParams.get('searchWord') || '';
 
   const [sortTypes, setSortTypes] = useState<SortType<SmsSendingListResponse>[]>([
     { accessor: 'senderPhoneNumber', type: SORT_TYPE.DEFAULT },
@@ -106,7 +105,7 @@ const ApplicationFormList = () => {
     () => ({
       page: parseInt(page, 10) - 1,
       size: parseInt(size, 10),
-      searchWord: searchWord.value,
+      searchWord,
       sort: sortParam,
     }),
     [page, size, searchWord, sortParam],
@@ -128,13 +127,6 @@ const ApplicationFormList = () => {
 
   const { makeDirty, isDirty } = useDirty(1);
 
-  const handleSubmit = (
-    e: { target: { searchWord: { value: string } } } & FormEvent<HTMLFormElement>,
-  ) => {
-    e.preventDefault();
-    setSearchWord({ value: e.target.searchWord.value });
-  };
-
   useEffect(() => {
     if (!isLoading) {
       setLoadedTableRows(tableRows.data);
@@ -155,12 +147,7 @@ const ApplicationFormList = () => {
     <Styled.PageWrapper>
       <Styled.Heading>SMS 발송 내역</Styled.Heading>
       <Styled.StickyContainer>
-        <SearchOptionBar
-          placeholder="발송번호, 발송자, 발송메모 검색"
-          searchWord={searchWord}
-          showFilterValues={false}
-          handleSubmit={handleSubmit}
-        />
+        <SearchOptionBar placeholder="발송번호, 발송자, 발송메모 검색" showFilterValues={false} />
       </Styled.StickyContainer>
       <Table
         prefix="sms"

--- a/src/pages/SmsSendingList/SmsSendingList.page.tsx
+++ b/src/pages/SmsSendingList/SmsSendingList.page.tsx
@@ -158,6 +158,7 @@ const ApplicationFormList = () => {
         <SearchOptionBar
           placeholder="발송번호, 발송자, 발송메모 검색"
           searchWord={searchWord}
+          showFilterValues={false}
           handleSubmit={handleSubmit}
         />
       </Styled.StickyContainer>


### PR DESCRIPTION
## 변경사항

- useHistory 훅에 쿼리스트링 유지할지 여부 관련된 훅 추가
- useHistory 테스트코드 추가
- 지원서 상세에서 뒤로가기할 때 필터 유지되도록 변경
  - filterValues를 state에서 query string으로 변경되도록 수정
  - searchWord를 state에서 query string으로 변경되도록 수정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)