### PR TITLE
SearchOptionBar 컴포넌트 filter 외부에서 주입받아 쓰도록 리팩토링

### DIFF
--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -1,62 +1,46 @@
-import React, { FormEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Input, Select } from '@/components';
 import { ButtonSize, ButtonShape } from '@/components/common/Button/Button.component';
 import * as Styled from './SearchOptionBar.styled';
 import { SelectOption, SelectSize } from '../Select/Select.component';
-import {
-  ApplicationConfirmationStatus,
-  ApplicationConfirmationStatusKeyType,
-  ApplicationResultStatus,
-  ApplicationResultStatusKeyType,
-} from '../ApplicationStatusBadge/ApplicationStatusBadge.component';
 
 export interface ApplicationFilterValuesType {
   confirmStatus: SelectOption;
   resultStatus: SelectOption;
 }
 
-interface SearchOptionBarProps {
-  placeholder?: string;
-  showFilterValues?: boolean;
+export interface SearchOptionBarFilter {
+  title: string;
+  key: string;
+  options: SelectOption[];
+  defaultOption?: SelectOption;
 }
 
-const DEFAULT = { label: '전체', value: '' };
+interface SearchOptionBarProps {
+  placeholder?: string;
+  filters?: SearchOptionBarFilter[];
+}
 
-const SearchOptionBar = ({ placeholder, showFilterValues = true }: SearchOptionBarProps) => {
+const SearchOptionBar = ({ placeholder, filters }: SearchOptionBarProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const ref = useRef<HTMLInputElement>(null);
 
-  const confirmStatus = searchParams.get('confirmStatus') || '';
-  const resultStatus = searchParams.get('resultStatus') || '';
   const searchWord = searchParams.get('searchWord') || '';
-
-  const [filterValues, setFilterValues] = useState<ApplicationFilterValuesType>({
-    confirmStatus: { label: '', value: '' },
-    resultStatus: { label: '', value: '' },
-  });
 
   const [searchKeyword, setSearchKeyword] = useState<{ value: string }>({ value: '' });
 
-  const handleApplicationConfirmStatus = (option: SelectOption) => {
-    if (option.value === DEFAULT.value) {
-      searchParams.delete('confirmStatus');
+  const handleChangeFilter = (selectedOption: SelectOption, filter: SearchOptionBarFilter) => {
+    const { key, defaultOption } = filter;
+
+    if (!!defaultOption && selectedOption.value === defaultOption.value) {
+      searchParams.delete(key);
       setSearchParams(searchParams);
+
       return;
     }
 
-    searchParams.set('confirmStatus', option.value);
-    setSearchParams(searchParams);
-  };
-
-  const handleApplicationResultStatus = (option: SelectOption) => {
-    if (option.value === DEFAULT.value) {
-      searchParams.delete('resultStatus');
-      setSearchParams(searchParams);
-      return;
-    }
-
-    searchParams.set('resultStatus', option.value);
+    searchParams.set(key, selectedOption.value);
     setSearchParams(searchParams);
   };
 
@@ -78,63 +62,17 @@ const SearchOptionBar = ({ placeholder, showFilterValues = true }: SearchOptionB
     setSearchParams(searchParams);
   };
 
+  const defaultValue = (filter: SearchOptionBarFilter) => {
+    const searchParam = searchParams.get(filter.key);
+
+    return filter.options.find((option) => option.value === searchParam);
+  };
+
   useLayoutEffect(() => {
     if (ref.current) {
       ref.current.value = searchKeyword.value;
     }
   }, [searchKeyword]);
-
-  const applicationConfirmStatusOptions = useMemo(
-    () => [
-      DEFAULT,
-      ...Object.keys(ApplicationConfirmationStatus).reduce<SelectOption[]>(
-        (acc, cur) => [
-          ...acc,
-          {
-            label: ApplicationConfirmationStatus[cur as ApplicationConfirmationStatusKeyType],
-            value: cur,
-          },
-        ],
-        [],
-      ),
-    ],
-    [],
-  );
-
-  const applicationResultStatusOptions = useMemo(
-    () => [
-      DEFAULT,
-      ...Object.keys(ApplicationResultStatus).reduce<SelectOption[]>(
-        (acc, cur) => [
-          ...acc,
-          {
-            label: ApplicationResultStatus[cur as ApplicationResultStatusKeyType],
-            value: cur,
-          },
-        ],
-        [],
-      ),
-    ],
-    [],
-  );
-
-  useEffect(() => {
-    const confirmStatusLabel =
-      applicationConfirmStatusOptions.find((option) => option.value === confirmStatus)?.label ?? '';
-
-    const resultStatusLabel =
-      applicationResultStatusOptions.find((option) => option.value === resultStatus)?.label ?? '';
-
-    setFilterValues({
-      confirmStatus: { label: confirmStatusLabel, value: confirmStatus },
-      resultStatus: { label: resultStatusLabel, value: resultStatus },
-    });
-  }, [
-    applicationConfirmStatusOptions,
-    applicationResultStatusOptions,
-    confirmStatus,
-    resultStatus,
-  ]);
 
   useEffect(() => {
     setSearchKeyword({ value: searchWord });
@@ -142,30 +80,20 @@ const SearchOptionBar = ({ placeholder, showFilterValues = true }: SearchOptionB
 
   return (
     <Styled.BarContainer onSubmit={handleSearch}>
-      {showFilterValues && (
-        <Styled.SelectContainer>
+      <Styled.SelectContainer>
+        {filters?.map((filter) => (
           <div>
-            <div>합격여부</div>
+            <div>{filter.title}</div>
             <Select
               size={SelectSize.xs}
-              options={applicationResultStatusOptions}
-              onChangeOption={handleApplicationResultStatus}
-              defaultValue={DEFAULT}
-              currentValue={filterValues.resultStatus}
+              options={filter.options}
+              onChangeOption={(option) => handleChangeFilter(option, filter)}
+              defaultValue={defaultValue(filter)}
             />
           </div>
-          <div>
-            <div>사용자 확인여부</div>
-            <Select
-              size={SelectSize.xs}
-              options={applicationConfirmStatusOptions}
-              onChangeOption={handleApplicationConfirmStatus}
-              defaultValue={DEFAULT}
-              currentValue={filterValues.confirmStatus}
-            />
-          </div>
-        </Styled.SelectContainer>
-      )}
+        ))}
+      </Styled.SelectContainer>
+
       <div />
       <Styled.SearchInputContainer>
         <Input ref={ref} name="searchWord" $size="xs" placeholder={placeholder} />

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -176,7 +176,7 @@ const ApplicationFormList = () => {
       <Styled.Heading>지원서 설문지 내역</Styled.Heading>
       <Styled.StickyContainer>
         <TeamNavigationTabs />
-        <SearchOptionBar placeholder="지원서 설문지 문서명 검색" showFilterValues={false} />
+        <SearchOptionBar placeholder="지원서 설문지 문서명 검색" />
       </Styled.StickyContainer>
       <Table
         prefix="application-form"

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -31,8 +31,11 @@ import ApplicationStatusBadge, {
   ApplicationResultStatusKeyType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
 import * as Styled from './ApplicationList.styled';
+import { SelectOption } from '@/components/common/Select/Select.component';
+import { SearchOptionBarFilter } from '@/components/common/SearchOptionBar/SearchOptionBar.component';
 
 const APPLICATION_EXTRA_SIZE = 100;
+const DEFAULT_OPTION = { label: '전체', value: '' };
 
 const ApplicationList = () => {
   const handleSMSModal = useSetRecoilState($modalByStorage(ModalKey.smsSendModalDialog));
@@ -220,6 +223,55 @@ const ApplicationList = () => {
     },
   ];
 
+  const applicationConfirmStatusOptions = useMemo(
+    () => [
+      DEFAULT_OPTION,
+      ...Object.keys(ApplicationConfirmationStatus).reduce<SelectOption[]>(
+        (acc, cur) => [
+          ...acc,
+          {
+            label: ApplicationConfirmationStatus[cur as ApplicationConfirmationStatusKeyType],
+            value: cur,
+          },
+        ],
+        [],
+      ),
+    ],
+    [],
+  );
+
+  const applicationResultStatusOptions = useMemo(
+    () => [
+      DEFAULT_OPTION,
+      ...Object.keys(ApplicationResultStatus).reduce<SelectOption[]>(
+        (acc, cur) => [
+          ...acc,
+          {
+            label: ApplicationResultStatus[cur as ApplicationResultStatusKeyType],
+            value: cur,
+          },
+        ],
+        [],
+      ),
+    ],
+    [],
+  );
+
+  const searchOptionBarFilters: SearchOptionBarFilter[] = [
+    {
+      title: '합격여부',
+      options: applicationResultStatusOptions,
+      key: 'resultStatus',
+      defaultOption: DEFAULT_OPTION,
+    },
+    {
+      title: '사용자 확인여부',
+      options: applicationConfirmStatusOptions,
+      key: 'confirmStatus',
+      defaultOption: DEFAULT_OPTION,
+    },
+  ];
+
   useEffect(() => {
     if (!isLoading) {
       setLoadedTableRows(tableRows.data);
@@ -248,7 +300,7 @@ const ApplicationList = () => {
       <Styled.Heading>지원서 내역</Styled.Heading>
       <Styled.StickyContainer>
         <TeamNavigationTabs />
-        <SearchOptionBar placeholder="이름, 전화번호 검색" />
+        <SearchOptionBar placeholder="이름, 전화번호 검색" filters={searchOptionBarFilters} />
       </Styled.StickyContainer>
       <Table
         prefix="application"

--- a/src/pages/SmsSendingList/SmsSendingList.page.tsx
+++ b/src/pages/SmsSendingList/SmsSendingList.page.tsx
@@ -147,7 +147,7 @@ const ApplicationFormList = () => {
     <Styled.PageWrapper>
       <Styled.Heading>SMS 발송 내역</Styled.Heading>
       <Styled.StickyContainer>
-        <SearchOptionBar placeholder="발송번호, 발송자, 발송메모 검색" showFilterValues={false} />
+        <SearchOptionBar placeholder="발송번호, 발송자, 발송메모 검색" />
       </Styled.StickyContainer>
       <Table
         prefix="sms"


### PR DESCRIPTION
## 변경사항

![image](https://user-images.githubusercontent.com/38802280/188803856-2c12a0d4-1a5a-42fd-bbb8-70fdbfaba4a2.png)


- SearchOptionBar (상단 검색바) 의 filter가 있는 경우의 수가 하나밖에 없어서, filter값이 컴포넌트 내부에서 관리되고 있었는데, 출첵 앱 기획상 다른 필터 (기수) 가 들어감으로써 화면별로 다른 filter가 있는 요구사항이 생겨서 filter를 외부에서 주입받아 쓰도록 변경하였습니다.
- 변경사항들을 보면 내부에서 관리되고 있는 Option들이 상위 컴포넌트로 이동했고, 나머지 로직은 전체적으로 거의 동일합니당

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)