### PR TITLE
출결점수 목록 페이지 UI 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   CreateApplicationForm,
   UpdateApplicationForm,
   ApplicationFormDetail,
+  AttendanceList,
   ErrorPage,
 } from './pages';
 
@@ -119,6 +120,14 @@ const App = () => {
               element={
                 <RequiredAuth isAuth={isAuthorized}>
                   <CreateApplicationForm />
+                </RequiredAuth>
+              }
+            />
+            <Route
+              path={PATH.ATTENDANCE}
+              element={
+                <RequiredAuth isAuth={isAuthorized}>
+                  <AttendanceList />
                 </RequiredAuth>
               }
             />

--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -30,6 +30,10 @@ const navigationItems: NavigationItem[] = [
     label: '지원서 설문지 내역',
     to: PATH.APPLICATION_FORM,
   },
+  {
+    label: '출결점수',
+    to: PATH.ATTENDANCE,
+  },
 ];
 
 const Header = () => {

--- a/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
+++ b/src/components/common/SearchOptionBar/SearchOptionBar.component.tsx
@@ -65,6 +65,10 @@ const SearchOptionBar = ({ placeholder, filters }: SearchOptionBarProps) => {
   const defaultValue = (filter: SearchOptionBarFilter) => {
     const searchParam = searchParams.get(filter.key);
 
+    if (!searchParam) {
+      return filter.options?.[0];
+    }
+
     return filter.options.find((option) => option.value === searchParam);
   };
 

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -9,6 +9,7 @@ export const PATH = {
   APPLICATION_FORM_DETAIL: '/application-form/:id',
   APPLICATION_FORM_CREATE: '/application-form/create',
   APPLICATION_FORM_UPDATE: '/application-form/update/:id',
+  ATTENDANCE: '/attendance',
   NOT_FOUND: '/404',
   FORBIDDEN: '/403',
 } as const;

--- a/src/pages/AttendanceList/AttendanceList.page.tsx
+++ b/src/pages/AttendanceList/AttendanceList.page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AttendanceList = () => {
+  return <>출석점수</>;
+};
+
+export default AttendanceList;

--- a/src/pages/AttendanceList/AttendanceList.page.tsx
+++ b/src/pages/AttendanceList/AttendanceList.page.tsx
@@ -1,7 +1,131 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { BottomCTA, Pagination, SearchOptionBar, Table, TeamNavigationTabs } from '@/components';
+import * as Styled from './AttendanceList.styled';
+import { SearchOptionBarFilter } from '@/components/common/SearchOptionBar/SearchOptionBar.component';
+import { SortType, TableColumn } from '@/components/common/Table/Table.component';
+import { SORT_TYPE } from '@/constants';
+import { usePagination } from '@/hooks';
+
+interface AttendanceListItem {
+  name: string;
+  userId: string;
+  platform: string;
+  score: number;
+}
+
+/**
+ * TODO(@mango906): 기수 key값 변형 필요
+ * options (기수 정보) 서버에서 받아오도록 변경 필요
+ */
+
+const filters: SearchOptionBarFilter[] = [
+  {
+    title: '기수',
+    key: 'steps',
+    options: [
+      { label: '12기', value: '12' },
+      { label: '11기', value: '11' },
+    ],
+    defaultOption: { label: '12기', value: '12' },
+  },
+];
+
+// TODO(@mango906): 서버쪽과 api 논의 후 accessor 밑 renderCustomCell 변경 필요
+const columns: TableColumn<AttendanceListItem>[] = [
+  {
+    title: '이름',
+    widthRatio: '25%',
+    accessor: 'name',
+    renderCustomCell: (cellValue) => (
+      <Styled.AttendanceListItemName>{cellValue as string}</Styled.AttendanceListItemName>
+    ),
+  },
+  {
+    title: '아이디',
+    widthRatio: '25%',
+    accessor: 'userId',
+  },
+  {
+    title: '플랫폼',
+    widthRatio: '25%',
+    accessor: 'platform',
+  },
+  {
+    title: '활동점수',
+    widthRatio: '25%',
+    accessor: 'score',
+  },
+];
+
+// TODO(@mango906): 서버쪽과 api 논의 후 서버쪽 데이터 쓰도록 변경 필요
+const rows: AttendanceListItem[] = new Array(10).fill({
+  name: '김경환',
+  userId: 'besign',
+  platform: 'Spring',
+  score: 3,
+});
 
 const AttendanceList = () => {
-  return <>출석점수</>;
+  const [sortTypes, setSortTypes] = useState<SortType<AttendanceListItem>[]>([
+    { accessor: 'name', type: SORT_TYPE.DEFAULT },
+    { accessor: 'score', type: SORT_TYPE.DEFAULT },
+  ]);
+
+  const totalCount = rows.length;
+
+  const { pageOptions, handleChangePage, handleChangeSize } = usePagination({
+    totalCount,
+    pagingSize: 10,
+  });
+
+  return (
+    <Styled.PageWrapper>
+      <Styled.Heading>출결점수</Styled.Heading>
+      <Styled.StickyContainer>
+        <TeamNavigationTabs />
+        <SearchOptionBar placeholder="이름 검색" filters={filters} />
+      </Styled.StickyContainer>
+      <Table
+        prefix="attendance"
+        topStickyHeight={14.1}
+        columns={columns}
+        rows={rows}
+        supportBar={{ totalSummaryText: '총 인원', totalCount }}
+        sortOptions={{
+          sortTypes,
+          disableMultiSort: true,
+          handleSortColumn: (_sortTypes) => {
+            setSortTypes(_sortTypes);
+          },
+        }}
+        pagination={
+          <Pagination
+            pageOptions={pageOptions}
+            selectableSize={{
+              selectBoxPosition: totalCount > 3 ? 'top' : 'bottom',
+              handleChangeSize,
+            }}
+            handleChangePage={handleChangePage}
+          />
+        }
+      />
+      <BottomCTA
+        boundaries={{
+          visibility: { topHeight: 179, bottomHeight: 20 },
+          noAnimation: { bottomHeight: 20 },
+        }}
+      >
+        <Pagination
+          pageOptions={pageOptions}
+          selectableSize={{
+            selectBoxPosition: totalCount > 3 ? 'top' : 'bottom',
+            handleChangeSize,
+          }}
+          handleChangePage={handleChangePage}
+        />
+      </BottomCTA>
+    </Styled.PageWrapper>
+  );
 };
 
 export default AttendanceList;

--- a/src/pages/AttendanceList/AttendanceList.styled.ts
+++ b/src/pages/AttendanceList/AttendanceList.styled.ts
@@ -1,0 +1,32 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const PageWrapper = styled.div`
+  padding: 2.8rem 0;
+`;
+
+export const Heading = styled.h2`
+  ${({ theme }) => css`
+    margin-bottom: 2.4rem;
+    color: ${theme.colors.gray80};
+    font-weight: 700;
+    font-size: 3.6rem;
+    line-height: 4.5rem;
+  `}
+`;
+
+export const StickyContainer = styled.div`
+  ${({ theme }) => css`
+    position: sticky;
+    top: 0;
+    z-index: ${theme.zIndex.select};
+    padding-bottom: 1.2rem;
+    background-color: ${theme.colors.white};
+  `}
+`;
+
+export const AttendanceListItemName = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.purple80};
+  `}
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,3 +7,4 @@ export { default as ApplicationFormList } from './ApplicationFormList/Applicatio
 export { default as ApplicationList } from './ApplicationList/ApplicationList.page';
 export { default as SmsSendingList } from './SmsSendingList/SmsSendingList.page';
 export { default as ErrorPage } from './ErrorPage/ErrorPage.page';
+export { default as AttendanceList } from './AttendanceList/AttendanceList.page';


### PR DESCRIPTION
## 변경사항



<img width="1507" alt="스크린샷 2022-09-07 오후 6 44 05" src="https://user-images.githubusercontent.com/38802280/188847357-766c6097-bbb0-4c5b-99f9-da147c540238.png">

출결점수 페이지 UI 추가

### 질문

Select에서 선택한 기수 정보를 쿼리 스트링에 담고 있는데, 현재 기수에 대한 정보는 쿼리 스트링에 담고 있는게 좋을까요 아니면, 쿼리스트링이 없다면 현재 기수인걸로 간주하는게 좋을까요 ? (구현된 내용은 현재 기수면 쿼리스트링에 담기지 않고, 쿼리스트링이 없다면 현재 기수로 판별)

### 작업 유형

- 신규 기능 추가

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)