### PR TITLE
활동점수 적용 모달 UI 추가

### DIFF
--- a/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import * as Styled from './ActivityScoreModalDialog.styled';
-import { Icon, ScoreTitle, ScoreType } from '..';
+import { Icon } from '..';
+
+import { RangeType, ScoreType, ScoreTitle } from '../constants';
 
 interface ActivityScoreModalDialogProps {
   onClose: () => void;
@@ -42,7 +44,7 @@ const ActivityScoreModalDialog = ({ onClose }: ActivityScoreModalDialogProps) =>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>점수</Styled.RowLabel>
-              <Styled.ScoreRangeType type={Styled.RangeType.Minus}>-0.5</Styled.ScoreRangeType>
+              <Styled.ScoreRangeType type={RangeType.Minus}>-0.5</Styled.ScoreRangeType>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>총 활동점수</Styled.RowLabel>

--- a/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
+++ b/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
@@ -2,11 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ModalWrapper } from '@/components';
 import { KeyOf } from '@/types';
-
-export const RangeType = {
-  Plus: 'Plus',
-  Minus: 'Minus',
-} as const;
+import { RangeType } from '..';
 
 export const ActivityScoreModalWrapper = styled(ModalWrapper)`
   width: 50rem;

--- a/src/components/ActivityScore/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component.tsx
+++ b/src/components/ActivityScore/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { InputField, RadioButton } from '@/components';
+
+import * as Styled from './ApplyActivityScoreModalDialog.styled';
+import { RangeType } from '../constants';
+import { getRangeText } from '../utils';
+import { InputSize } from '@/components/common/Input/Input.component';
+
+interface ApplyActivityScoreModalDialogProps {
+  onClose: () => void;
+}
+
+interface FormValues {
+  date: string;
+  memo: string;
+}
+
+const scoreTypes = [
+  {
+    label: '출결',
+    items: [
+      { label: '출석', rangeType: RangeType.Normal, range: 0 },
+      { label: '지각', rangeType: RangeType.Minus, range: 0.5 },
+      { label: '결석', rangeType: RangeType.Minus, range: 1 },
+    ],
+  },
+  {
+    label: '활동',
+    items: [
+      { label: '프로젝트 배포 실패', rangeType: RangeType.Minus, range: 1 },
+      { label: '프로젝트 배포 성공', rangeType: RangeType.Plus, range: 1 },
+      { label: '전체 세미나 발표', rangeType: RangeType.Plus, range: 1 },
+      { label: '매시업 콘텐츠 글 작성', rangeType: RangeType.Plus, range: 0.5 },
+      { label: '뭐든준비위원회', rangeType: RangeType.Plus, range: 1 },
+    ],
+  },
+  {
+    label: '직위',
+    items: [
+      { label: '회장', rangeType: RangeType.Minus, range: 100 },
+      { label: '부회장', rangeType: RangeType.Plus, range: 100 },
+      { label: '스태프', rangeType: RangeType.Plus, range: 99 },
+      { label: '프로젝트팀 팀장', rangeType: RangeType.Plus, range: 2 },
+      { label: '프로젝트팀 부팀장', rangeType: RangeType.Plus, range: 2 },
+    ],
+  },
+];
+
+const ApplyActivityScoreModalDialog = ({ onClose }: ApplyActivityScoreModalDialogProps) => {
+  const { register } = useForm<FormValues>();
+
+  return (
+    <Styled.ApplyActivityScoreModalWrapper
+      heading="활동점수 적용"
+      handleCloseModal={onClose}
+      footer={{
+        confirmButton: { label: '적용', onClick: onClose },
+        cancelButton: { label: '취소', onClick: onClose },
+      }}
+    >
+      <Styled.ModalInner>
+        <Styled.ScoreSection>
+          <Styled.ScoreSectionLabel>
+            활동점수 리스트
+            <Styled.RequiredDot />
+          </Styled.ScoreSectionLabel>
+          {scoreTypes.map((scoreType) => {
+            return (
+              <React.Fragment key={scoreType.label}>
+                <Styled.Label>{scoreType.label}</Styled.Label>
+                <Styled.RadioButtonGroup>
+                  {scoreType.items.map((scoreTypeItem) => (
+                    <Styled.RadioButtonGroupItem key={scoreTypeItem.label}>
+                      <RadioButton label={scoreTypeItem.label} />
+                      <Styled.ScoreText rangeType={scoreTypeItem.rangeType}>
+                        {getRangeText(scoreTypeItem.range, scoreTypeItem.rangeType)}
+                      </Styled.ScoreText>
+                    </Styled.RadioButtonGroupItem>
+                  ))}
+                </Styled.RadioButtonGroup>
+              </React.Fragment>
+            );
+          })}
+        </Styled.ScoreSection>
+        <Styled.Divider />
+        <Styled.InputSection>
+          <Styled.StyledDatePickerField
+            $size={InputSize.md}
+            label="날짜"
+            placeholder="내용을 입력해주세요"
+            required
+            {...register('date', { required: true })}
+          />
+          <InputField
+            {...register('memo')}
+            fill
+            label="메모"
+            $size={InputSize.md}
+            placeholder="내용을 입력해주세요"
+          />
+        </Styled.InputSection>
+      </Styled.ModalInner>
+    </Styled.ApplyActivityScoreModalWrapper>
+  );
+};
+
+export default ApplyActivityScoreModalDialog;

--- a/src/components/ActivityScore/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.styled.ts
+++ b/src/components/ActivityScore/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.styled.ts
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+import { css, Theme } from '@emotion/react';
+import { DatePickerField, ModalWrapper } from '@/components';
+
+import { RangeType } from '..';
+import { ValueOf } from '@/types';
+
+const getScoreTextStyle = (rangeType: ValueOf<typeof RangeType>, theme: Theme) => {
+  if (rangeType === RangeType.Plus) {
+    return css`
+      color: ${theme.colors.blue70};
+    `;
+  }
+
+  if (rangeType === RangeType.Minus) {
+    return css`
+      color: ${theme.colors.red70};
+    `;
+  }
+
+  if (rangeType === RangeType.Normal) {
+    return css`
+      color: ${theme.colors.gray70};
+    `;
+  }
+};
+
+export const ApplyActivityScoreModalWrapper = styled(ModalWrapper)`
+  width: 100rem;
+`;
+
+export const ModalInner = styled.div`
+  display: flex;
+  flex: 1;
+  padding: 0 2.4rem;
+`;
+
+export const Divider = styled.div`
+  ${({ theme }) => css`
+    width: 0.1rem;
+    margin: 0 2.4rem;
+    background-color: ${theme.colors.gray20};
+  `}
+`;
+
+export const ScoreSection = styled.div`
+  width: 35.2rem;
+`;
+
+export const ScoreSectionLabel = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.medium15};
+
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    margin-bottom: 0.6rem;
+    color: ${theme.colors.gray70};
+  `}
+`;
+
+export const InputSection = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2.4rem;
+`;
+
+export const StyledDatePickerField = styled(DatePickerField)`
+  position: absolute;
+`;
+
+export const RequiredDot = styled.span`
+  ${({ theme }) => css`
+    width: 0.6rem;
+    height: 0.6rem;
+    background-color: ${theme.colors.red50};
+    border-radius: 50%;
+  `}
+`;
+
+export const Label = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.regular15};
+
+    display: block;
+    color: ${theme.colors.gray70};
+  `}
+`;
+
+export const RadioButtonGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  margin: 1.6rem 0;
+`;
+
+export const RadioButtonGroupItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  span {
+    ${({ theme }) => css`
+      ${theme.fonts.medium16}
+    `}
+  }
+`;
+
+export const ScoreText = styled.span<{ rangeType: ValueOf<typeof RangeType> }>`
+  ${({ theme, rangeType }) => css`
+    ${theme.fonts.medium16};
+    ${getScoreTextStyle(rangeType, theme)};
+  `}
+`;

--- a/src/components/ActivityScore/constants.ts
+++ b/src/components/ActivityScore/constants.ts
@@ -29,3 +29,9 @@ export const ScoreTitle = {
   [ScoreType.PROJECT_SUB_LEADER]: '프로젝트 부팀장',
   [ScoreType.PREPARE]: '준비 위원회',
 };
+
+export const RangeType = {
+  Plus: 'Plus',
+  Minus: 'Minus',
+  Normal: 'Normal',
+} as const;

--- a/src/components/ActivityScore/index.ts
+++ b/src/components/ActivityScore/index.ts
@@ -2,4 +2,6 @@ export { default as PersonalInfoCard } from './PersonalInfoCard/PersonalInfoCard
 export { default as ScoreCard } from './ScoreCard/ScoreCard.component';
 export { default as Icon } from './Icon/Icon.component';
 export { default as ActivityScoreModalDialog } from './ActivityScoreModalDialog/ActivityScoreModalDialog.component';
+export { default as ApplyActivityScoreModalDialog } from './ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component';
+export * from './utils';
 export * from './constants';

--- a/src/components/ActivityScore/utils.ts
+++ b/src/components/ActivityScore/utils.ts
@@ -1,0 +1,15 @@
+import { ValueOf } from '@/types';
+
+import { RangeType } from './constants';
+
+export const getRangeText = (range: number, rangeType: ValueOf<typeof RangeType>) => {
+  if (rangeType === RangeType.Plus) {
+    return `+${range}`;
+  }
+
+  if (rangeType === RangeType.Minus) {
+    return `-${range}`;
+  }
+
+  return range;
+};

--- a/src/components/common/DatePicker/DatePicker.component.tsx
+++ b/src/components/common/DatePicker/DatePicker.component.tsx
@@ -81,12 +81,13 @@ const DayCell = ({
 };
 
 export interface DatePickerProps {
+  className?: string;
   handleSelectDate: (clickedDate: Dayjs) => void;
-  selectedDate: Dayjs;
+  selectedDate: Dayjs | null;
 }
 
-const DatePicker = ({ handleSelectDate, selectedDate }: DatePickerProps) => {
-  const [date, setDate] = useState<Dayjs>(selectedDate);
+const DatePicker = ({ className, handleSelectDate, selectedDate }: DatePickerProps) => {
+  const [date, setDate] = useState<Dayjs>(selectedDate ?? dayjs());
 
   const rows = handleGenerateDateRows(date);
 
@@ -99,7 +100,7 @@ const DatePicker = ({ handleSelectDate, selectedDate }: DatePickerProps) => {
   };
 
   return (
-    <Styled.DatePickerWrapper>
+    <Styled.DatePickerWrapper className={className}>
       <Styled.DatePickerHeader>
         <ArrowLeft onClick={() => handleChangeMonth('prev')} />
         <div>{date.format('YYYY.M')}</div>

--- a/src/components/common/DatePicker/DatePicker.styled.ts
+++ b/src/components/common/DatePicker/DatePicker.styled.ts
@@ -14,6 +14,7 @@ export const DatePickerWrapper = styled.div`
     background-color: ${theme.colors.white};
     border: 0.1rem solid ${theme.colors.gray30};
     border-radius: 1.2rem;
+    filter: drop-shadow(0px 0.5rem 2rem rgba(0, 0, 0, 0.08));
   `}
 `;
 
@@ -28,7 +29,7 @@ export const DatePickerHeader = styled.div`
     border-bottom: 0.1rem solid ${theme.colors.gray30};
 
     & div {
-      ${theme.fonts.bold24}
+      ${theme.fonts.bold16}
 
       cursor: default;
     }

--- a/src/components/common/Input/Input.component.tsx
+++ b/src/components/common/Input/Input.component.tsx
@@ -15,14 +15,25 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   label?: string;
   description?: string;
   errorMessage?: string;
+  fill?: boolean;
 }
 
 const Input = (
-  { id, className, $size, label, errorMessage, required, description, ...resetProps }: InputProps,
+  {
+    id,
+    className,
+    $size,
+    label,
+    errorMessage,
+    required,
+    description,
+    fill,
+    ...resetProps
+  }: InputProps,
   ref: React.Ref<HTMLInputElement>,
 ) => {
   return (
-    <Styled.InputWrapper className={className}>
+    <Styled.InputWrapper className={className} fill={fill}>
       {label && (
         <Styled.InputLabel htmlFor={id}>
           <span>{label}</span>

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -3,15 +3,27 @@ import styled from '@emotion/styled';
 
 import { InputSizeType } from './Input.component';
 
+interface InputWrapperProps {
+  fill?: boolean;
+}
+
 interface StyledInputProps {
   $size: InputSizeType;
   errorMessage?: string;
+  fill?: boolean;
 }
 
-export const InputWrapper = styled.div`
+export const InputWrapper = styled.div<InputWrapperProps>`
   display: flex;
   flex: 1;
   flex-direction: column;
+
+  ${({ fill }) => css`
+    ${fill &&
+    css`
+      width: 100%;
+    `}
+  `}
 `;
 
 export const InputLabel = styled.label`

--- a/src/components/common/RadioButton/RadioButton.component.tsx
+++ b/src/components/common/RadioButton/RadioButton.component.tsx
@@ -2,7 +2,7 @@ import React, { MouseEventHandler } from 'react';
 import * as Styled from './RadioButton.styled';
 
 export interface RadioButtonProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
-  handleClickButton: MouseEventHandler<HTMLInputElement>;
+  handleClickButton?: MouseEventHandler<HTMLInputElement>;
   disabled?: boolean;
   defaultChecked?: boolean;
   label?: string;

--- a/src/components/common/RadioButton/RadioButton.styled.ts
+++ b/src/components/common/RadioButton/RadioButton.styled.ts
@@ -18,7 +18,7 @@ export const RadioButtonWrapper = styled.label<StyledRadioButtonLabelProps>`
     align-items: center;
     justify-content: flex-start;
     width: fit-content;
-    height: 1.2rem;
+    height: 2.2rem;
     padding: 0 0;
     cursor: pointer;
     user-select: none;
@@ -37,8 +37,8 @@ export const RadioButtonMark = styled.span`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 2.2rem;
+    height: 2.2rem;
     background-color: ${theme.colors.white};
     border: solid 0.1rem ${theme.colors.gray30};
     border-radius: 50%;
@@ -48,12 +48,12 @@ export const RadioButtonMark = styled.span`
     }
 
     label input:checked ~ & {
-      border-color: ${theme.colors.purple70};
+      background-color: ${theme.colors.purple70};
 
       & > span {
-        width: 0.5rem;
-        height: 0.5rem;
-        background-color: ${theme.colors.purple70};
+        width: 1rem;
+        height: 1rem;
+        background-color: ${theme.colors.white};
         border-radius: 50%;
       }
     }
@@ -67,6 +67,6 @@ export const RadioButtonMark = styled.span`
 export const RadioButtonText = styled.span`
   ${({ theme }) => css`
     ${theme.fonts.medium14}
-    padding-left: 2rem;
+    padding-left: 3.8rem;
   `}
 `;

--- a/src/components/fields/DatePickerField/DatePickerField.component.tsx
+++ b/src/components/fields/DatePickerField/DatePickerField.component.tsx
@@ -1,0 +1,62 @@
+import { FieldValues, UseFormRegister } from 'react-hook-form';
+import React, { forwardRef, useState, useRef, useMemo } from 'react';
+import { Dayjs } from 'dayjs';
+import { DatePicker, Input } from '@/components';
+
+import { InputProps } from '@/components/common/Input/Input.component';
+import { useOnClickOutSide, useToggleState } from '@/hooks';
+import { formatDate } from '@/utils';
+
+type DatePickerFieldProps = InputProps;
+
+const DatePickerField = (
+  { className, onClick, ...restProps }: DatePickerFieldProps,
+  ref: React.Ref<HTMLInputElement>,
+) => {
+  const [isDatePickerOpened, toggleDatePickerOpened] = useToggleState(false);
+  const [selectedDate, setSelectedDate] = useState<Dayjs | null>(null);
+  const containerRef = useRef(null);
+
+  const formattedDate = useMemo(() => {
+    if (!selectedDate) {
+      return '';
+    }
+
+    return formatDate(selectedDate.toDate(), 'YYYY.MM.DD');
+  }, [selectedDate]);
+
+  const handleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    onClick?.(event);
+
+    if (!isDatePickerOpened) {
+      toggleDatePickerOpened();
+    }
+  };
+
+  const handleSelectDate = (clickedDate: Dayjs) => {
+    setSelectedDate(clickedDate);
+    toggleDatePickerOpened();
+  };
+
+  useOnClickOutSide(containerRef, () => {
+    if (isDatePickerOpened) toggleDatePickerOpened();
+  });
+
+  return (
+    <div ref={containerRef}>
+      <Input ref={ref} value={formattedDate} readOnly onClick={handleClick} {...restProps} />
+      {isDatePickerOpened && (
+        <DatePicker
+          className={className}
+          selectedDate={selectedDate}
+          handleSelectDate={handleSelectDate}
+        />
+      )}
+    </div>
+  );
+};
+
+export default forwardRef<
+  HTMLInputElement,
+  DatePickerFieldProps & ReturnType<UseFormRegister<FieldValues>>
+>(DatePickerField);

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -1,3 +1,4 @@
 export { default as InputField } from './InputField/InputField.component';
 export { default as ToggleButtonField } from './ToggleButtonField/ToggleButtonField.component';
 export { default as SelectField } from './SelectField/SelectField.component';
+export { default as DatePickerField } from './DatePickerField/DatePickerField.component';

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -5,6 +5,7 @@ import { useHistory, useToggleState } from '@/hooks';
 import { PATH } from '@/constants';
 import {
   ActivityScoreModalDialog,
+  ApplyActivityScoreModalDialog,
   Icon,
   PersonalInfoCard,
   ScoreCard,
@@ -37,7 +38,9 @@ const rows: ScoreHistory[] = Object.values(ScoreType).map((type) => ({
 
 const ActivityScoreDetail = () => {
   const { handleGoBack } = useHistory();
-  const [isScoreAddModalOpened, toggleScoreAddModalOpened] = useToggleState(false);
+  const [isActivityScoreModalOpened, toggleActivityScoreModalOpened] = useToggleState(false);
+  const [isApplyActivityScoreModalOpened, toggleApplyActivityScoreModalOpened] =
+    useToggleState(false);
 
   const columns: TableColumn<ScoreHistory>[] = [
     {
@@ -55,7 +58,7 @@ const ActivityScoreDetail = () => {
       widthRatio: '23%',
       accessor: 'title',
       renderCustomCell: (cellValue) => (
-        <Styled.ActivityTitle onClick={toggleScoreAddModalOpened}>
+        <Styled.ActivityTitle onClick={toggleActivityScoreModalOpened}>
           {cellValue as string}
         </Styled.ActivityTitle>
       ),
@@ -94,12 +97,22 @@ const ActivityScoreDetail = () => {
         <Styled.Content>
           <Styled.ContentHeader>
             <h3>활동점수 히스토리</h3>
-            <Button shape={ButtonShape.defaultLine} label="점수 추가" Icon={Plus} />
+            <Button
+              shape={ButtonShape.defaultLine}
+              label="점수 추가"
+              Icon={Plus}
+              onClick={toggleApplyActivityScoreModalOpened}
+            />
           </Styled.ContentHeader>
           <Table prefix="score-history" columns={columns} rows={rows} supportBar={{}} />
         </Styled.Content>
       </Styled.ActivityScoreDetailPage>
-      {isScoreAddModalOpened && <ActivityScoreModalDialog onClose={toggleScoreAddModalOpened} />}
+      {isActivityScoreModalOpened && (
+        <ActivityScoreModalDialog onClose={toggleActivityScoreModalOpened} />
+      )}
+      {isApplyActivityScoreModalOpened && (
+        <ApplyActivityScoreModalDialog onClose={toggleApplyActivityScoreModalOpened} />
+      )}
     </>
   );
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,7 +8,8 @@ type DateFormat =
   | 'YYYY년 M월 D일 A h시 m분'
   | 'YYYY년 M월 D일(ddd)'
   | 'a hh시 mm분'
-  | 'YYYY년 M월 D일(ddd) a hh시 mm분';
+  | 'YYYY년 M월 D일(ddd) a hh시 mm분'
+  | 'YYYY.MM.DD';
 
 export const formatDate = (date: string | Date, format: DateFormat) => {
   return dayjs(date).format(format);


### PR DESCRIPTION
## 변경사항

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/38802280/192557884-95e18403-73e6-4e13-b5ba-a057d6186cda.png">


- RadioButton 스타일 수정
- RadioButton handleClickButton 옵셔널한 인자로 수정
- DatePicker 컴포넌트 수정
  - 스타일 수정
  - 날짜선택됨을 기본ㄹ값으로 오늘이 아닌, 비워둘수 있게 수정
- DatePickerField 컴포넌트 추가
- Input Fill 옵션 추가
- 활동점수 적용 모달 ui 추가

### 작업 유형

- 신규 기능 추가

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)