### PR TITLE
활동점수 상세 모달 UI 추가

### DIFF
--- a/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import * as Styled from './ActivityScoreModalDialog.styled';
+import { Icon, ScoreTitle, ScoreType } from '..';
+
+interface ActivityScoreModalDialogProps {
+  onClose: () => void;
+}
+
+const ActivityScoreModalDialog = ({ onClose }: ActivityScoreModalDialogProps) => {
+  const handleCancel = () => {
+    // TODO(@mango906): 취소하기 로직 작성 필요
+  };
+
+  return (
+    <Styled.ActivityScoreModalWrapper
+      heading="활동점수 상세"
+      handleCloseModal={onClose}
+      footer={{
+        confirmButton: { label: '점수 취소하기', onClick: handleCancel },
+        position: 'center',
+      }}
+    >
+      <Styled.ModalInner>
+        <Styled.DetailCard>
+          <Icon type={ScoreType.ATTENDANCE} size={64} />
+          <Styled.ActivityTitle>{ScoreTitle[ScoreType.ATTENDANCE]}</Styled.ActivityTitle>
+          <Styled.Divider />
+          <Styled.Content>
+            <Styled.Row>
+              <Styled.RowLabel>세미나 정보</Styled.RowLabel>
+              <Styled.RowContent>3차 전체 세미나</Styled.RowContent>
+            </Styled.Row>
+            <Styled.Row>
+              <Styled.RowLabel>등록일시</Styled.RowLabel>
+              <Styled.RowContent>2022년 3월 2일 오후 2시 30분</Styled.RowContent>
+            </Styled.Row>
+            <Styled.Row>
+              <Styled.RowLabel>메모</Styled.RowLabel>
+              <Styled.RowContent>
+                제 시간에 출석을 했었다 날이 좋아서 날이 좋지 않아서 출석 점수를 줘버렸다..
+              </Styled.RowContent>
+            </Styled.Row>
+            <Styled.Row>
+              <Styled.RowLabel>점수</Styled.RowLabel>
+              <Styled.ScoreRangeType type={Styled.RangeType.Minus}>-0.5</Styled.ScoreRangeType>
+            </Styled.Row>
+            <Styled.Row>
+              <Styled.RowLabel>총 활동점수</Styled.RowLabel>
+              <Styled.RowContent>0</Styled.RowContent>
+            </Styled.Row>
+          </Styled.Content>
+        </Styled.DetailCard>
+      </Styled.ModalInner>
+    </Styled.ActivityScoreModalWrapper>
+  );
+};
+
+export default ActivityScoreModalDialog;

--- a/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
+++ b/src/components/ActivityScore/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
@@ -1,0 +1,85 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { ModalWrapper } from '@/components';
+import { KeyOf } from '@/types';
+
+export const RangeType = {
+  Plus: 'Plus',
+  Minus: 'Minus',
+} as const;
+
+export const ActivityScoreModalWrapper = styled(ModalWrapper)`
+  width: 50rem;
+  max-width: 50rem;
+`;
+
+export const ModalInner = styled.div`
+  padding: 1.2rem 2.4rem;
+`;
+
+export const DetailCard = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2.4rem 2rem;
+    background-color: ${theme.colors.gray5};
+    border-radius: 2rem;
+  `}
+`;
+
+export const ActivityTitle = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.bold18};
+
+    margin-top: 1.6rem;
+  `}
+`;
+
+export const Divider = styled.div`
+  ${({ theme }) => css`
+    gap: 1.6rem;
+    width: 100%;
+    height: 0.1rem;
+    margin: 2rem 0;
+    background-color: ${theme.colors.gray20};
+  `}
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  width: 100%;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+`;
+
+export const RowLabel = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.regular14};
+
+    width: 6.6rem;
+    color: ${theme.colors.gray60};
+    white-space: nowrap;
+  `}
+`;
+
+export const RowContent = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.medium14};
+
+    flex: 1;
+    color: ${theme.colors.gray80};
+  `}
+`;
+
+export const ScoreRangeType = styled(RowContent)<{ type: KeyOf<typeof RangeType> }>`
+  ${({ theme, type }) => css`
+    color: ${type === RangeType.Minus ? theme.colors.red70 : theme.colors.blue70};
+  `}
+`;

--- a/src/components/ActivityScore/Icon/Icon.component.tsx
+++ b/src/components/ActivityScore/Icon/Icon.component.tsx
@@ -34,10 +34,16 @@ const scoreIcon = {
 
 interface IconProps {
   type: ValueOf<typeof ScoreType>;
+  size?: number;
 }
 
-const Icon = ({ type }: IconProps) => {
-  return scoreIcon[type];
+const Icon = ({ type, size = 44 }: IconProps) => {
+  const icon = React.cloneElement(scoreIcon[type], {
+    width: size,
+    height: size,
+  });
+
+  return icon;
 };
 
 export default Icon;

--- a/src/components/ActivityScore/index.ts
+++ b/src/components/ActivityScore/index.ts
@@ -1,4 +1,5 @@
 export { default as PersonalInfoCard } from './PersonalInfoCard/PersonalInfoCard.component';
 export { default as ScoreCard } from './ScoreCard/ScoreCard.component';
 export { default as Icon } from './Icon/Icon.component';
+export { default as ActivityScoreModalDialog } from './ActivityScoreModalDialog/ActivityScoreModalDialog.component';
 export * from './constants';

--- a/src/components/common/ModalWrapper/ModalWrapper.component.tsx
+++ b/src/components/common/ModalWrapper/ModalWrapper.component.tsx
@@ -32,7 +32,7 @@ export interface ModalProps extends Children {
   className?: string;
   heading?: string;
   footer: {
-    cancelButton: {
+    cancelButton?: {
       shape?: ButtonShapeType;
       label?: string;
       onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -142,17 +142,20 @@ const ModalWrapper = ({
               </Styled.ModalHeader>
             )}
             <Styled.ModalContent isContentScroll={isContentScroll}>{children}</Styled.ModalContent>
+
             <Styled.ModalFooter position={footer.position || Position.right}>
-              <Button
-                $size={ButtonSize.sm}
-                shape={ButtonShape.defaultLine}
-                {...footer.cancelButton}
-                onClick={
-                  footer.cancelButton.onClick
-                    ? footer.cancelButton.onClick
-                    : () => handleCloseModal()
-                }
-              />
+              {footer?.cancelButton && (
+                <Button
+                  $size={ButtonSize.sm}
+                  shape={ButtonShape.defaultLine}
+                  {...footer.cancelButton}
+                  onClick={
+                    footer.cancelButton.onClick
+                      ? footer.cancelButton.onClick
+                      : () => handleCloseModal()
+                  }
+                />
+              )}
               {footer?.confirmButton && (
                 <Button
                   $size={ButtonSize.sm}

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { BackButton, Button, Table } from '@/components';
 import * as Styled from './ActivityScoreDetail.styled';
-import { useHistory } from '@/hooks';
+import { useHistory, useToggleState } from '@/hooks';
 import { PATH } from '@/constants';
 import {
+  ActivityScoreModalDialog,
   Icon,
   PersonalInfoCard,
   ScoreCard,
@@ -25,44 +26,6 @@ interface ScoreHistory {
   totalScore: number;
 }
 
-const columns: TableColumn<ScoreHistory>[] = [
-  {
-    title: '-',
-    widthRatio: '7%',
-    accessor: 'type',
-    renderCustomCell: (cellValue) => (
-      <Styled.IconWrapper>
-        <Icon type={cellValue as ValueOf<typeof ScoreType>} />
-      </Styled.IconWrapper>
-    ),
-  },
-  {
-    title: '제목',
-    widthRatio: '23%',
-    accessor: 'title',
-  },
-  {
-    title: '세미나 정보',
-    widthRatio: '23%',
-    accessor: 'seminar',
-  },
-  {
-    title: '등록 일시',
-    widthRatio: '23%',
-    accessor: 'createdAt',
-  },
-  {
-    title: '점수',
-    widthRatio: '12%',
-    accessor: 'score',
-  },
-  {
-    title: '총 활동 점수',
-    widthRatio: '12%',
-    accessor: 'totalScore',
-  },
-];
-
 const rows: ScoreHistory[] = Object.values(ScoreType).map((type) => ({
   type,
   title: ScoreTitle[type],
@@ -74,23 +37,70 @@ const rows: ScoreHistory[] = Object.values(ScoreType).map((type) => ({
 
 const ActivityScoreDetail = () => {
   const { handleGoBack } = useHistory();
+  const [isScoreAddModalOpened, toggleScoreAddModalOpened] = useToggleState(false);
+
+  const columns: TableColumn<ScoreHistory>[] = [
+    {
+      title: '-',
+      widthRatio: '7%',
+      accessor: 'type',
+      renderCustomCell: (cellValue) => (
+        <Styled.IconWrapper>
+          <Icon type={cellValue as ValueOf<typeof ScoreType>} />
+        </Styled.IconWrapper>
+      ),
+    },
+    {
+      title: '제목',
+      widthRatio: '23%',
+      accessor: 'title',
+      renderCustomCell: (cellValue) => (
+        <Styled.ActivityTitle onClick={toggleScoreAddModalOpened}>
+          {cellValue as string}
+        </Styled.ActivityTitle>
+      ),
+    },
+    {
+      title: '세미나 정보',
+      widthRatio: '23%',
+      accessor: 'seminar',
+    },
+    {
+      title: '등록 일시',
+      widthRatio: '23%',
+      accessor: 'createdAt',
+    },
+    {
+      title: '점수',
+      widthRatio: '12%',
+      accessor: 'score',
+    },
+    {
+      title: '총 활동 점수',
+      widthRatio: '12%',
+      accessor: 'totalScore',
+    },
+  ];
 
   return (
-    <Styled.ActivityScoreDetailPage>
-      <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.ACTIVITY_SCORE)} />
-      <Styled.Headline>활동점수</Styled.Headline>
-      <Styled.Row>
-        <PersonalInfoCard />
-        <ScoreCard />
-      </Styled.Row>
-      <Styled.Content>
-        <Styled.ContentHeader>
-          <h3>활동점수 히스토리</h3>
-          <Button shape={ButtonShape.defaultLine} label="점수 추가" Icon={Plus} />
-        </Styled.ContentHeader>
-        <Table prefix="score-history" columns={columns} rows={rows} supportBar={{}} />
-      </Styled.Content>
-    </Styled.ActivityScoreDetailPage>
+    <>
+      <Styled.ActivityScoreDetailPage>
+        <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.ACTIVITY_SCORE)} />
+        <Styled.Headline>활동점수</Styled.Headline>
+        <Styled.Row>
+          <PersonalInfoCard />
+          <ScoreCard />
+        </Styled.Row>
+        <Styled.Content>
+          <Styled.ContentHeader>
+            <h3>활동점수 히스토리</h3>
+            <Button shape={ButtonShape.defaultLine} label="점수 추가" Icon={Plus} />
+          </Styled.ContentHeader>
+          <Table prefix="score-history" columns={columns} rows={rows} supportBar={{}} />
+        </Styled.Content>
+      </Styled.ActivityScoreDetailPage>
+      {isScoreAddModalOpened && <ActivityScoreModalDialog onClose={toggleScoreAddModalOpened} />}
+    </>
   );
 };
 

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.styled.ts
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.styled.ts
@@ -61,3 +61,21 @@ export const IconWrapper = styled.div`
     vertical-align: middle;
   }
 `;
+
+export const ActivityTitle = styled.span`
+  ${({ theme }) => css`
+    overflow: hidden;
+    color: ${theme.colors.purple80};
+    white-space: nowrap;
+    text-align: center;
+    text-overflow: ellipsis;
+    cursor: pointer;
+
+    &:hover {
+      color: ${theme.colors.purple90};
+      font-weight: 500;
+      text-decoration: underline;
+      text-underline-position: under;
+    }
+  `};
+`;

--- a/webpack/webpack.base.js
+++ b/webpack/webpack.base.js
@@ -56,6 +56,11 @@ module.exports = {
         use: [
           {
             loader: '@svgr/webpack',
+            options: {
+              svgoConfig: {
+                plugins: [{removeViewBox: false}],
+              },
+            },
           },
         ],
       },


### PR DESCRIPTION
## 변경사항

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/38802280/191562600-90de4577-cb2f-4acd-b198-6e82e66eaf02.png">

- svgr이 기본적으로 viewBox를 제거하는데, viewBox를 제거함으로써 크기를 조절할 수 없어서, viewBox를 제거하지 않도록 수정
- ModalWrapper 컴포넌트에 confirmButton 옵션만 존재하는 경우도 있어서 cancelButton도 옵셔널하게 변경
- 활동점수 Icon 사이즈 조절할 수 있도록 추가
- 활동점수 상세 모달 UI 추가

### 작업 유형

- 신규 기능 추가
- 프로젝트 설정(웹팩, 바벨, 린팅 등)

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)