### PR TITLE
활동점수 취소 api 연동

### DIFF
--- a/src/api/scoreHistory.ts
+++ b/src/api/scoreHistory.ts
@@ -1,5 +1,9 @@
-import { BaseResponse, ScoreHistoryAddRequest } from '@/types';
+import { BaseResponse, ScoreHistoryAddRequest, ScoreHistoryCancelRequest } from '@/types';
 import http from '@/api/core';
 
 export const postScoreHistoryAdd = (params: ScoreHistoryAddRequest): Promise<BaseResponse<{}>> =>
   http.post({ url: '/score-history/add', data: params });
+
+export const postScoreHistoryCancel = (
+  params: ScoreHistoryCancelRequest,
+): Promise<BaseResponse<{}>> => http.post({ url: '/score-history/cancel', data: params });

--- a/src/components/ActivityScore/ScoreCard/ScoreCard.component.tsx
+++ b/src/components/ActivityScore/ScoreCard/ScoreCard.component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getScoreRangeType } from '../utils';
 import * as Styled from './ScoreCard.styled';
 
 interface ScoreCardProps {
@@ -8,8 +9,8 @@ interface ScoreCardProps {
 const ScoreCard = ({ totalScore }: ScoreCardProps) => {
   return (
     <Styled.Wrapper>
-      <Styled.Headline>총 활동 점수</Styled.Headline>
-      <Styled.Score>{totalScore}점</Styled.Score>
+      <Styled.Headline>총 활동점수</Styled.Headline>
+      <Styled.Score type={getScoreRangeType(totalScore)}>{totalScore}점</Styled.Score>
     </Styled.Wrapper>
   );
 };

--- a/src/components/ActivityScore/ScoreCard/ScoreCard.styled.ts
+++ b/src/components/ActivityScore/ScoreCard/ScoreCard.styled.ts
@@ -1,5 +1,8 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { ValueOf } from '@/types';
+import { RangeType } from '../constants';
+import { getScoreTextColor } from '../utils';
 
 export const Wrapper = styled.div`
   ${({ theme }) => css`
@@ -22,10 +25,9 @@ export const Headline = styled.h4`
   `};
 `;
 
-export const Score = styled.span`
-  ${({ theme }) => css`
+export const Score = styled.span<{ type: ValueOf<typeof RangeType> }>`
+  ${({ theme, type }) => css`
     ${theme.fonts.bold46};
-
-    color: ${theme.colors.green70};
+    ${getScoreTextColor(type, theme)}
   `}
 `;

--- a/src/components/ActivityScore/index.ts
+++ b/src/components/ActivityScore/index.ts
@@ -1,6 +1,5 @@
 export { default as PersonalInfoCard } from './PersonalInfoCard/PersonalInfoCard.component';
 export { default as ScoreCard } from './ScoreCard/ScoreCard.component';
 export { default as Icon } from './Icon/Icon.component';
-export { default as ActivityScoreModalDialog } from './ActivityScoreModalDialog/ActivityScoreModalDialog.component';
 export * from './utils';
 export * from './constants';

--- a/src/components/ActivityScore/utils.ts
+++ b/src/components/ActivityScore/utils.ts
@@ -1,3 +1,4 @@
+import { css, Theme } from '@emotion/react';
 import { ValueOf } from '@/types';
 
 import { RangeType } from './constants';
@@ -12,4 +13,36 @@ export const getRangeText = (range: number, rangeType: ValueOf<typeof RangeType>
   }
 
   return range;
+};
+
+export const getScoreRangeType = (score: number) => {
+  if (score < 0) {
+    return RangeType.Minus;
+  }
+
+  if (score > 0) {
+    return RangeType.Plus;
+  }
+
+  return RangeType.Normal;
+};
+
+export const getScoreTextColor = (type: ValueOf<typeof RangeType>, theme: Theme) => {
+  let textColor = '';
+
+  if (type === RangeType.Normal) {
+    textColor = theme.colors.gray80;
+  }
+
+  if (type === RangeType.Minus) {
+    textColor = theme.colors.red70;
+  }
+
+  if (type === RangeType.Plus) {
+    textColor = theme.colors.blue70;
+  }
+
+  return css`
+    color: ${textColor};
+  `;
 };

--- a/src/components/common/ModalViewer/ModalViewer.component.tsx
+++ b/src/components/common/ModalViewer/ModalViewer.component.tsx
@@ -9,6 +9,7 @@ import {
   SmsSendDetailListModalDialog,
   SmsSendModalDialog,
   ApplyActivityScoreModalDialog,
+  ActivityScoreModalDialog,
 } from '@/components';
 import { AlertModalDialogProps } from '../AlertModalDialog/AlertModalDialog.component';
 import { ChangeResultModalDialogProps } from '@/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component';
@@ -16,6 +17,7 @@ import { SmsSendModalDialogProps } from '../SmsSendModalDialog/SmsSendModalDialo
 import { SmsSendDetailListModalDialogProps } from '../../modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';
 import { SmsSendDetailInfoModalDialogProps } from '@/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component';
 import { ApplyActivityScoreModalDialogProps } from '@/components/modal/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component';
+import { ActivityScoreModalDialogProps } from '@/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component';
 
 const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
   const modal = useRecoilValue($modalByStorage(modalKey));
@@ -57,6 +59,15 @@ const Modal = ({ modalKey }: { modalKey: ModalKeyType }) => {
       <ApplyActivityScoreModalDialog
         key={modalKey}
         {...(modal.props as ApplyActivityScoreModalDialogProps)}
+      />
+    );
+  }
+
+  if (modalKey === ModalKey.activityScoreModalDialog && modal.isOpen && modal.props) {
+    return (
+      <ActivityScoreModalDialog
+        key={modalKey}
+        {...(modal.props as ActivityScoreModalDialogProps)}
       />
     );
   }

--- a/src/components/common/ModalWrapper/ModalWrapper.component.tsx
+++ b/src/components/common/ModalWrapper/ModalWrapper.component.tsx
@@ -42,6 +42,7 @@ export interface ModalProps extends Children {
       label?: string;
       onClick: MouseEventHandler<HTMLButtonElement>;
       isLoading?: boolean;
+      disabled?: boolean;
     };
     position?: PositionType;
   };

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
+import { useSetRecoilState } from 'recoil';
 import * as Styled from './ActivityScoreModalDialog.styled';
-import { Icon } from '..';
+import { Icon } from '@/components/ActivityScore';
 
-import { RangeType, ScoreType, ScoreTitle } from '../constants';
+import { RangeType, ScoreType, ScoreTitle } from '@/components/ActivityScore/constants';
+import { $modalByStorage, ModalKey } from '@/store';
 
-interface ActivityScoreModalDialogProps {
-  onClose: () => void;
-}
+export interface ActivityScoreModalDialogProps {}
 
-const ActivityScoreModalDialog = ({ onClose }: ActivityScoreModalDialogProps) => {
+const ActivityScoreModalDialog = () => {
+  const handleActivityScoreModal = useSetRecoilState(
+    $modalByStorage(ModalKey.activityScoreModalDialog),
+  );
+
+  const handleCloseModal = () =>
+    handleActivityScoreModal({ key: ModalKey.activityScoreModalDialog, isOpen: false });
+
   const handleCancel = () => {
     // TODO(@mango906): 취소하기 로직 작성 필요
   };
@@ -16,7 +23,7 @@ const ActivityScoreModalDialog = ({ onClose }: ActivityScoreModalDialogProps) =>
   return (
     <Styled.ActivityScoreModalWrapper
       heading="활동점수 상세"
-      handleCloseModal={onClose}
+      handleCloseModal={handleCloseModal}
       footer={{
         confirmButton: { label: '점수 취소하기', onClick: handleCancel },
         position: 'center',

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@/components/ActivityScore';
 import { RangeType, ScoreType } from '@/components/ActivityScore/constants';
 import { $modalByStorage, ModalKey } from '@/store';
 import { ScoreHistory, ValueOf } from '@/types';
-import { parsePlaceholderWhenEmpty, request } from '@/utils';
+import { formatDate, parsePlaceholderWhenEmpty, request } from '@/utils';
 
 import * as api from '@/api';
 import { useToast } from '@/hooks';
@@ -33,6 +33,7 @@ const ActivityScoreModalDialog = ({
     accumulatedScore,
     score,
     isCanceled,
+    date,
   } = scoreHistory;
 
   const [isLoading, setIsLoading] = useState(false);
@@ -133,7 +134,7 @@ const ActivityScoreModalDialog = ({
             <Styled.Row>
               <Styled.RowLabel>등록일시</Styled.RowLabel>
               <Styled.RowContent isCanceled={isCanceled}>
-                2022년 3월 2일 오후 2시 30분
+                {formatDate(date, 'YYYY년 M월 D일 A h시 m분')}
               </Styled.RowContent>
             </Styled.Row>
             <Styled.Row>

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -3,12 +3,16 @@ import { useSetRecoilState } from 'recoil';
 import * as Styled from './ActivityScoreModalDialog.styled';
 import { Icon } from '@/components/ActivityScore';
 
-import { RangeType, ScoreType, ScoreTitle } from '@/components/ActivityScore/constants';
+import { RangeType, ScoreType } from '@/components/ActivityScore/constants';
 import { $modalByStorage, ModalKey } from '@/store';
+import { ScoreHistory, ValueOf } from '@/types';
+import { parsePlaceholderWhenEmpty } from '@/utils';
 
-export interface ActivityScoreModalDialogProps {}
+export interface ActivityScoreModalDialogProps {
+  scoreHistory: ScoreHistory;
+}
 
-const ActivityScoreModalDialog = () => {
+const ActivityScoreModalDialog = ({ scoreHistory }: ActivityScoreModalDialogProps) => {
   const handleActivityScoreModal = useSetRecoilState(
     $modalByStorage(ModalKey.activityScoreModalDialog),
   );
@@ -19,6 +23,8 @@ const ActivityScoreModalDialog = () => {
   const handleCancel = () => {
     // TODO(@mango906): 취소하기 로직 작성 필요
   };
+
+  const { scoreType, scoreName, scheduleName, memo, accumulatedScore, score } = scoreHistory;
 
   return (
     <Styled.ActivityScoreModalWrapper
@@ -31,13 +37,13 @@ const ActivityScoreModalDialog = () => {
     >
       <Styled.ModalInner>
         <Styled.DetailCard>
-          <Icon type={ScoreType.ATTENDANCE} size={64} />
-          <Styled.ActivityTitle>{ScoreTitle[ScoreType.ATTENDANCE]}</Styled.ActivityTitle>
+          <Icon type={scoreType as ValueOf<typeof ScoreType>} size={64} />
+          <Styled.ActivityTitle>{scoreName}</Styled.ActivityTitle>
           <Styled.Divider />
           <Styled.Content>
             <Styled.Row>
               <Styled.RowLabel>세미나 정보</Styled.RowLabel>
-              <Styled.RowContent>3차 전체 세미나</Styled.RowContent>
+              <Styled.RowContent>{parsePlaceholderWhenEmpty(scheduleName)}</Styled.RowContent>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>등록일시</Styled.RowLabel>
@@ -45,17 +51,15 @@ const ActivityScoreModalDialog = () => {
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>메모</Styled.RowLabel>
-              <Styled.RowContent>
-                제 시간에 출석을 했었다 날이 좋아서 날이 좋지 않아서 출석 점수를 줘버렸다..
-              </Styled.RowContent>
+              <Styled.RowContent>{parsePlaceholderWhenEmpty(memo)}</Styled.RowContent>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>점수</Styled.RowLabel>
-              <Styled.ScoreRangeType type={RangeType.Minus}>-0.5</Styled.ScoreRangeType>
+              <Styled.ScoreRangeType type={RangeType.Minus}>{score}</Styled.ScoreRangeType>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>총 활동점수</Styled.RowLabel>
-              <Styled.RowContent>0</Styled.RowContent>
+              <Styled.RowContent>{accumulatedScore}</Styled.RowContent>
             </Styled.Row>
           </Styled.Content>
         </Styled.DetailCard>

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component.tsx
@@ -24,8 +24,16 @@ const ActivityScoreModalDialog = ({
   generationNumber,
   memberId,
 }: ActivityScoreModalDialogProps) => {
-  const { scoreHistoryId, scoreType, scoreName, scheduleName, memo, accumulatedScore, score } =
-    scoreHistory;
+  const {
+    scoreHistoryId,
+    scoreType,
+    scoreName,
+    scheduleName,
+    memo,
+    accumulatedScore,
+    score,
+    isCanceled,
+  } = scoreHistory;
 
   const [isLoading, setIsLoading] = useState(false);
   const { handleAddToast } = useToast();
@@ -98,31 +106,47 @@ const ActivityScoreModalDialog = ({
       heading="활동점수 상세"
       handleCloseModal={handleCloseModal}
       footer={{
-        confirmButton: { label: '점수 취소하기', onClick: handleCancelActivityScore, isLoading },
+        confirmButton: {
+          label: '점수 취소하기',
+          onClick: handleCancelActivityScore,
+          isLoading,
+          disabled: isCanceled,
+        },
         position: 'center',
       }}
     >
       <Styled.ModalInner>
         <Styled.DetailCard>
           <Icon type={scoreType as ValueOf<typeof ScoreType>} size={64} />
-          <Styled.ActivityTitle>{scoreName}</Styled.ActivityTitle>
+          <Styled.ActivityTitle>
+            {scoreName}
+            {isCanceled && <Styled.CancelLabel>취소</Styled.CancelLabel>}
+          </Styled.ActivityTitle>
           <Styled.Divider />
           <Styled.Content>
             <Styled.Row>
               <Styled.RowLabel>세미나 정보</Styled.RowLabel>
-              <Styled.RowContent>{parsePlaceholderWhenEmpty(scheduleName)}</Styled.RowContent>
+              <Styled.RowContent isCanceled={isCanceled}>
+                {parsePlaceholderWhenEmpty(scheduleName)}
+              </Styled.RowContent>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>등록일시</Styled.RowLabel>
-              <Styled.RowContent>2022년 3월 2일 오후 2시 30분</Styled.RowContent>
+              <Styled.RowContent isCanceled={isCanceled}>
+                2022년 3월 2일 오후 2시 30분
+              </Styled.RowContent>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>메모</Styled.RowLabel>
-              <Styled.RowContent>{parsePlaceholderWhenEmpty(memo)}</Styled.RowContent>
+              <Styled.RowContent isCanceled={isCanceled}>
+                {parsePlaceholderWhenEmpty(memo)}
+              </Styled.RowContent>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>점수</Styled.RowLabel>
-              <Styled.ScoreRangeType type={RangeType.Minus}>{score}</Styled.ScoreRangeType>
+              <Styled.ScoreRangeType isCanceled={isCanceled} type={RangeType.Minus}>
+                {score}
+              </Styled.ScoreRangeType>
             </Styled.Row>
             <Styled.Row>
               <Styled.RowLabel>총 활동점수</Styled.RowLabel>

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ModalWrapper } from '@/components';
 import { KeyOf } from '@/types';
-import { RangeType } from '..';
+import { RangeType } from '@/components/ActivityScore';
 
 export const ActivityScoreModalWrapper = styled(ModalWrapper)`
   width: 50rem;

--- a/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
+++ b/src/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.styled.ts
@@ -28,6 +28,9 @@ export const ActivityTitle = styled.span`
   ${({ theme }) => css`
     ${theme.fonts.bold18};
 
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
     margin-top: 1.6rem;
   `}
 `;
@@ -65,17 +68,29 @@ export const RowLabel = styled.span`
   `}
 `;
 
-export const RowContent = styled.span`
-  ${({ theme }) => css`
+export const RowContent = styled.span<{ isCanceled?: boolean }>`
+  ${({ theme, isCanceled }) => css`
     ${theme.fonts.medium14};
 
     flex: 1;
     color: ${theme.colors.gray80};
+    text-decoration: ${isCanceled ? 'line-through' : ''};
   `}
 `;
 
 export const ScoreRangeType = styled(RowContent)<{ type: KeyOf<typeof RangeType> }>`
   ${({ theme, type }) => css`
     color: ${type === RangeType.Minus ? theme.colors.red70 : theme.colors.blue70};
+  `}
+`;
+
+export const CancelLabel = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.medium13};
+
+    padding: 0.2rem 1rem;
+    color: ${theme.colors.red70};
+    background-color: ${theme.colors.red20};
+    border-radius: 10rem;
   `}
 `;

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -2,3 +2,4 @@ export { default as ChangeResultModalDialog } from './ChangeResultModalDialog/Ch
 export { default as SmsSendDetailInfoModalDialog } from './SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component';
 export { default as SmsSendDetailListModalDialog } from './SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';
 export { default as ApplyActivityScoreModalDialog } from './ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component';
+export { default as ActivityScoreModalDialog } from './ActivityScoreModalDialog/ActivityScoreModalDialog.component';

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -103,7 +103,11 @@ const ActivityScoreDetail = () => {
                 handleActivityScoreModal({
                   key: ModalKey.activityScoreModalDialog,
                   isOpen: true,
-                  props: { scoreHistory },
+                  props: {
+                    scoreHistory,
+                    generationNumber: parseUrlParam(generationNumberParam),
+                    memberId: parseUrlParam(memberIdParam),
+                  },
                 })
               }
             >

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -59,9 +59,41 @@ const ActivityScoreDetail = () => {
     {
       title: '제목',
       widthRatio: '23%',
-      accessor: ['scoreName', 'isCanceled'],
+      accessor: [
+        'accumulatedScore',
+        'date',
+        'isCanceled',
+        'memo',
+        'scheduleName',
+        'score',
+        'scoreHistoryId',
+        'scoreName',
+        'scoreType',
+      ],
       renderCustomCell: (cellValue) => {
-        const [scoreName, isCanceled] = cellValue as [string, boolean];
+        const [
+          accumulatedScore,
+          date,
+          isCanceled,
+          memo,
+          scheduleName,
+          score,
+          scoreHistoryId,
+          scoreName,
+          scoreType,
+        ] = cellValue as [number, string, boolean, string, string, number, number, string, string];
+
+        const scoreHistory = {
+          accumulatedScore,
+          date,
+          isCanceled,
+          memo,
+          scheduleName,
+          score,
+          scoreHistoryId,
+          scoreName,
+          scoreType,
+        };
 
         return (
           <>
@@ -71,7 +103,7 @@ const ActivityScoreDetail = () => {
                 handleActivityScoreModal({
                   key: ModalKey.activityScoreModalDialog,
                   isOpen: true,
-                  props: {},
+                  props: { scoreHistory },
                 })
               }
             >

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -3,10 +3,9 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { BackButton, Button, Table } from '@/components';
 import * as Styled from './ActivityScoreDetail.styled';
-import { useHistory, useToggleState } from '@/hooks';
+import { useHistory } from '@/hooks';
 import { PATH } from '@/constants';
 import {
-  ActivityScoreModalDialog,
   Icon,
   PersonalInfoCard,
   RangeType,
@@ -36,11 +35,14 @@ const getScoreRangeType = (score: number) => {
 
 const ActivityScoreDetail = () => {
   const { handleGoBack } = useHistory();
-  const [isActivityScoreModalOpened, toggleActivityScoreModalOpened] = useToggleState(false);
   const { generationNumber: generationNumberParam, memberId: memberIdParam } = useParams();
 
   const handleApplyActivityScoreModal = useSetRecoilState(
     $modalByStorage(ModalKey.applyActivityScoreModalDialog),
+  );
+
+  const handleActivityScoreModal = useSetRecoilState(
+    $modalByStorage(ModalKey.activityScoreModalDialog),
   );
 
   const columns: TableColumn<ScoreHistory>[] = [
@@ -63,7 +65,16 @@ const ActivityScoreDetail = () => {
 
         return (
           <>
-            <Styled.ActivityTitle isCanceled={isCanceled} onClick={toggleActivityScoreModalOpened}>
+            <Styled.ActivityTitle
+              isCanceled={isCanceled}
+              onClick={() =>
+                handleActivityScoreModal({
+                  key: ModalKey.activityScoreModalDialog,
+                  isOpen: true,
+                  props: {},
+                })
+              }
+            >
               {scoreName}
             </Styled.ActivityTitle>
             {isCanceled && <Styled.CancelLabel>취소</Styled.CancelLabel>}
@@ -125,50 +136,45 @@ const ActivityScoreDetail = () => {
     );
 
   return (
-    <>
-      <Styled.ActivityScoreDetailPage>
-        <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.ACTIVITY_SCORE)} />
-        <Styled.Headline>활동점수 상세</Styled.Headline>
-        <Styled.Row>
-          <PersonalInfoCard
-            name={name}
-            platform={platform}
-            identification={identification}
-            generationNumber={generationNumber}
+    <Styled.ActivityScoreDetailPage>
+      <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.ACTIVITY_SCORE)} />
+      <Styled.Headline>활동점수 상세</Styled.Headline>
+      <Styled.Row>
+        <PersonalInfoCard
+          name={name}
+          platform={platform}
+          identification={identification}
+          generationNumber={generationNumber}
+        />
+        <ScoreCard totalScore={totalScore} />
+      </Styled.Row>
+      <Styled.Content>
+        <Styled.ContentHeader>
+          <h3>활동점수 히스토리</h3>
+          <Button
+            shape={ButtonShape.defaultLine}
+            label="점수 추가"
+            Icon={Plus}
+            onClick={() => {
+              handleApplyActivityScoreModal({
+                key: ModalKey.applyActivityScoreModalDialog,
+                isOpen: true,
+                props: {
+                  generationNumber: parseUrlParam(generationNumberParam),
+                  memberId: parseUrlParam(memberIdParam),
+                },
+              });
+            }}
           />
-          <ScoreCard totalScore={totalScore} />
-        </Styled.Row>
-        <Styled.Content>
-          <Styled.ContentHeader>
-            <h3>활동점수 히스토리</h3>
-            <Button
-              shape={ButtonShape.defaultLine}
-              label="점수 추가"
-              Icon={Plus}
-              onClick={() => {
-                handleApplyActivityScoreModal({
-                  key: ModalKey.applyActivityScoreModalDialog,
-                  isOpen: true,
-                  props: {
-                    generationNumber: parseUrlParam(generationNumberParam),
-                    memberId: parseUrlParam(memberIdParam),
-                  },
-                });
-              }}
-            />
-          </Styled.ContentHeader>
-          <Table
-            prefix="score-history"
-            columns={columns}
-            rows={scoreHistoryResponses}
-            supportBar={{}}
-          />
-        </Styled.Content>
-      </Styled.ActivityScoreDetailPage>
-      {isActivityScoreModalOpened && (
-        <ActivityScoreModalDialog onClose={toggleActivityScoreModalOpened} />
-      )}
-    </>
+        </Styled.ContentHeader>
+        <Table
+          prefix="score-history"
+          columns={columns}
+          rows={scoreHistoryResponses}
+          supportBar={{}}
+        />
+      </Styled.Content>
+    </Styled.ActivityScoreDetailPage>
   );
 };
 

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.page.tsx
@@ -6,9 +6,9 @@ import * as Styled from './ActivityScoreDetail.styled';
 import { useHistory } from '@/hooks';
 import { PATH } from '@/constants';
 import {
+  getScoreRangeType,
   Icon,
   PersonalInfoCard,
-  RangeType,
   ScoreCard,
   ScoreType,
 } from '@/components/ActivityScore';
@@ -20,18 +20,6 @@ import Plus from '@/assets/svg/plus-16.svg';
 import { $memberDetail } from '@/store/member';
 import { $modalByStorage, ModalKey } from '@/store';
 import { formatDate, parseUrlParam } from '@/utils';
-
-const getScoreRangeType = (score: number) => {
-  if (score < 0) {
-    return RangeType.Minus;
-  }
-
-  if (score > 0) {
-    return RangeType.Plus;
-  }
-
-  return RangeType.Normal;
-};
 
 const ActivityScoreDetail = () => {
   const { handleGoBack } = useHistory();
@@ -157,7 +145,7 @@ const ActivityScoreDetail = () => {
       },
     },
     {
-      title: '총 활동 점수',
+      title: '총 점수',
       widthRatio: '12%',
       accessor: 'accumulatedScore',
     },

--- a/src/pages/ActivityScoreDetail/ActivityScoreDetail.styled.ts
+++ b/src/pages/ActivityScoreDetail/ActivityScoreDetail.styled.ts
@@ -1,27 +1,7 @@
-import { css, Theme } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { RangeType } from '@/components/ActivityScore';
+import { getScoreTextColor, RangeType } from '@/components/ActivityScore';
 import { ValueOf } from '@/types';
-
-const getScoreTextColor = (type: ValueOf<typeof RangeType>, theme: Theme) => {
-  let textColor = '';
-
-  if (type === RangeType.Normal) {
-    textColor = theme.colors.gray80;
-  }
-
-  if (type === RangeType.Minus) {
-    textColor = theme.colors.red70;
-  }
-
-  if (type === RangeType.Plus) {
-    textColor = theme.colors.blue70;
-  }
-
-  return css`
-    color: ${textColor};
-  `;
-};
 
 export const ActivityScoreDetailPage = styled.div`
   padding: 2rem 0;

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -8,6 +8,7 @@ import { SmsSendModalDialogProps } from '@/components/common/SmsSendModalDialog/
 import { SmsSendDetailInfoModalDialogProps } from '@/components/modal/SmsSendDetailInfoModalDialog/SmsSendDetailInfoModalDialog.component';
 import { SmsSendDetailListModalDialogProps } from '@/components/modal/SmsSendDetailListModalDialog/SmsSendDetailListModalDialog.component';
 import { ApplyActivityScoreModalDialogProps } from '@/components/modal/ApplyActivityScoreModalDialog/ApplyActivityScoreModalDialog.component';
+import { ActivityScoreModalDialogProps } from '@/components/modal/ActivityScoreModalDialog/ActivityScoreModalDialog.component';
 
 export const ModalKey = {
   alertModalDialog: 'alertModalDialog',
@@ -16,6 +17,7 @@ export const ModalKey = {
   smsSendDetailInfoModalDialog: 'smsSendDetailInfoModalDialog',
   smsSendDetailListModalDialog: 'smsSendDetailListModalDialog',
   applyActivityScoreModalDialog: 'applyActivityScoreModalDialog',
+  activityScoreModalDialog: 'activityScoreModalDialog',
 } as const;
 
 export type ModalKeyType = ValueOf<typeof ModalKey>;
@@ -25,7 +27,8 @@ export type ModalProps =
   | SmsSendDetailListModalDialogProps
   | SmsSendDetailInfoModalDialogProps
   | ChangeResultModalDialogProps
-  | ApplyActivityScoreModalDialogProps;
+  | ApplyActivityScoreModalDialogProps
+  | ActivityScoreModalDialogProps;
 
 export interface Modal {
   key: ModalKeyType;

--- a/src/types/dto/scoreHistory.ts
+++ b/src/types/dto/scoreHistory.ts
@@ -8,3 +8,8 @@ export interface ScoreHistoryAddRequest {
   memo: string;
   scoreType: ValueOf<typeof ScoreType>;
 }
+
+export interface ScoreHistoryCancelRequest {
+  memo: string;
+  scoreHistoryId: number;
+}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -10,3 +10,11 @@ export const sortString = (type: ValueOf<typeof SORT_TYPE>, one: string, another
 
   return compared ? 1 : -1;
 };
+
+export const parsePlaceholderWhenEmpty = (value: string | null | undefined, parsingText = '-') => {
+  if (!value) {
+    return parsingText;
+  }
+
+  return value;
+};


### PR DESCRIPTION
## 변경사항

- 활동점수 상세 모달 로직 modal 쪽으로 이동
- 활동점수 상세 모달 데이터 연동
- 활동점수 취소 api 연동
- 활동점수 상세 모달 취소된 케이스 추가
  - 중간줄 쳐져있고 취소 버튼이 비활성화
- 총 활동점수 점수에 따라 글씨색 변경되도록 수정

(활동점수 상세 모달 취소된 케이스)

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/38802280/196030125-cec7f57d-a10c-4848-8133-88fd0a069016.png">


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)