### PR TITLE
기수정보 선택할 수 있도록 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @mango906 @Baek2back @HaJunRyu
+*   @mango906 @Baek2back @HaJunRyu @sanoopark

--- a/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
+++ b/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useSearchParams } from 'react-router-dom';
+import { Select } from '@/components/common';
+
+import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
+import { $generations } from '@/store';
+
+const GenerationSelect = () => {
+  const generations = useRecoilValue($generations);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const options = generations.map((generation) => ({
+    label: `${generation.generationNumber}기`,
+    value: generation.generationNumber.toString(),
+  }));
+
+  const defaultValue: SelectOption | undefined = generations.length
+    ? {
+        label: `${generations[0].generationNumber}기`,
+        value: `${generations[0].generationNumber}`,
+      }
+    : undefined;
+
+  const handleChangeGeneration = (selectedOption: SelectOption) => {
+    if (selectedOption.value === defaultValue?.value) {
+      searchParams.delete('generationNumber');
+      setSearchParams(searchParams);
+
+      return;
+    }
+
+    searchParams.set('generationNumber', selectedOption.value);
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <Select
+      size={SelectSize.xs}
+      options={options}
+      onChangeOption={(option) => handleChangeGeneration(option)}
+      defaultValue={defaultValue}
+    />
+  );
+};
+
+export default GenerationSelect;

--- a/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
+++ b/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
@@ -1,45 +1,40 @@
-import React from 'react';
-import { useRecoilValue } from 'recoil';
-import { useSearchParams } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
 import { Select } from '@/components/common';
 
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
-import { $generations } from '@/store';
+import { $generationNumber, $generations } from '@/store';
 
 const GenerationSelect = () => {
   const generations = useRecoilValue($generations);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [generationNumber, setGenerationNumber] = useRecoilState($generationNumber);
 
-  const options = generations.map((generation) => ({
+  const options: SelectOption[] = generations.map((generation) => ({
     label: `${generation.generationNumber}기`,
-    value: generation.generationNumber.toString(),
+    value: `${generation.generationNumber}`,
   }));
 
-  const defaultValue: SelectOption | undefined = generations.length
-    ? {
-        label: `${generations[0].generationNumber}기`,
-        value: `${generations[0].generationNumber}`,
-      }
-    : undefined;
-
   const handleChangeGeneration = (selectedOption: SelectOption) => {
-    if (selectedOption.value === defaultValue?.value) {
-      searchParams.delete('generationNumber');
-      setSearchParams(searchParams);
-
-      return;
-    }
-
-    searchParams.set('generationNumber', selectedOption.value);
-    setSearchParams(searchParams);
+    setGenerationNumber(parseInt(selectedOption.value, 10));
   };
+
+  useEffect(() => {
+    if (generations.length && !generationNumber) {
+      setGenerationNumber(generations[0].generationNumber);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generationNumber, generations]);
 
   return (
     <Select
+      currentValue={{
+        label: `${generationNumber}기`,
+        value: `${generationNumber}`,
+      }}
       size={SelectSize.xs}
       options={options}
       onChangeOption={(option) => handleChangeGeneration(option)}
-      defaultValue={defaultValue}
     />
   );
 };

--- a/src/components/Generation/index.ts
+++ b/src/components/Generation/index.ts
@@ -1,0 +1,1 @@
+export { default as GenerationSelect } from './GenerationSelect/GenerationSelect.component';

--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Header } from '@/components';
 import * as Styled from './Layout.styled';
+import { PATH } from '@/constants';
+import { GenerationSelect } from '@/components/Generation';
 
 const Layout = () => {
   const { pathname } = useLocation();
@@ -14,11 +16,24 @@ const Layout = () => {
     [pathname],
   );
 
+  const isListPage = useMemo(
+    () =>
+      [PATH.APPLICATION, PATH.APPLICATION_FORM, PATH.ACTIVITY_SCORE].some(
+        (each) => pathname === each,
+      ),
+    [pathname],
+  );
+
   return (
     <>
       <Header />
       <Styled.Main isBackgroundGray={isBackgroundGray}>
         <section>
+          {isListPage && (
+            <Styled.SelectWrapper>
+              <GenerationSelect />
+            </Styled.SelectWrapper>
+          )}
           <Outlet />
         </section>
       </Styled.Main>

--- a/src/components/common/Layout/Layout.styled.ts
+++ b/src/components/common/Layout/Layout.styled.ts
@@ -17,3 +17,7 @@ export const Main = styled.main<StyledMainProps>`
     }
   `}
 `;
+
+export const SelectWrapper = styled.div`
+  margin-top: 4rem;
+`;

--- a/src/components/common/Select/Select.component.tsx
+++ b/src/components/common/Select/Select.component.tsx
@@ -73,7 +73,8 @@ const Select = (
     if (defaultValue) {
       setSelectedOption(defaultValue);
     }
-  }, [defaultValue]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValue?.value]);
 
   useEffect(() => {
     if (currentValue) {

--- a/src/pages/ActivityScoreList/ActivityScoreList.page.tsx
+++ b/src/pages/ActivityScoreList/ActivityScoreList.page.tsx
@@ -3,24 +3,21 @@ import { useLocation, useSearchParams } from 'react-router-dom';
 import { useRecoilStateLoadable, useRecoilValue } from 'recoil';
 import { BottomCTA, Pagination, SearchOptionBar, Table, TeamNavigationTabs } from '@/components';
 import * as Styled from './ActivityScoreList.styled';
-import { SearchOptionBarFilter } from '@/components/common/SearchOptionBar/SearchOptionBar.component';
 import { SortType, TableColumn } from '@/components/common/Table/Table.component';
 import { PATH, SORT_TYPE } from '@/constants';
 import { useMyTeam, usePagination } from '@/hooks';
-import { $generations } from '@/store';
+import { $generationNumber } from '@/store';
 import { MemberRequest, MemberResponse } from '@/types';
 import { $members } from '@/store/member';
-import { parseUrlParam } from '@/utils';
 
 const ActivityScoreList = () => {
   const [searchParams] = useSearchParams();
-  const generations = useRecoilValue($generations);
+  const generationNumber = useRecoilValue($generationNumber);
+
   const { isMyTeam } = useMyTeam();
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
-  const generationNumber =
-    parseUrlParam(searchParams.get('generation')) || generations?.[0]?.generationNumber;
 
   const team = searchParams.get('team') || '';
   const searchWord = searchParams.get('searchWord') || '';
@@ -37,17 +34,6 @@ const ActivityScoreList = () => {
     const { accessor, type } = matched;
     return `${accessor},${type}`;
   }, [sortTypes]);
-
-  const filters: SearchOptionBarFilter[] = [
-    {
-      title: '기수',
-      key: 'generation',
-      options: generations.map((generation) => ({
-        label: `${generation.generationNumber}기`,
-        value: generation.generationNumber.toString(),
-      })),
-    },
-  ];
 
   const { pathname, search } = useLocation();
 
@@ -115,7 +101,7 @@ const ActivityScoreList = () => {
       <Styled.Heading>활동점수</Styled.Heading>
       <Styled.StickyContainer>
         <TeamNavigationTabs />
-        <SearchOptionBar placeholder="이름 검색" filters={filters} />
+        <SearchOptionBar placeholder="이름 검색" />
       </Styled.StickyContainer>
       <Table
         prefix="activity-score"

--- a/src/pages/ActivityScoreList/ActivityScoreList.styled.ts
+++ b/src/pages/ActivityScoreList/ActivityScoreList.styled.ts
@@ -20,7 +20,7 @@ export const StickyContainer = styled.div`
   ${({ theme }) => css`
     position: sticky;
     top: 0;
-    z-index: ${theme.zIndex.select};
+    z-index: calc(${theme.zIndex.sticky} + 1);
     padding-bottom: 1.2rem;
     background-color: ${theme.colors.white};
   `}

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -18,7 +18,7 @@ import { useDirty, usePagination, useToggleState } from '@/hooks';
 import { $applicationForms, $teamIdByName } from '@/store';
 import { ApplicationFormResponse, Question, ApplicationFormRequest } from '@/types';
 import { PATH, SORT_TYPE } from '@/constants';
-import { formatDate } from '@/utils';
+import { formatDate, parseUrlParam } from '@/utils';
 import { TableColumn, SortType } from '@/components/common/Table/Table.component';
 import { TeamType, RoleType } from '@/components/common/UserProfile/UserProfile.component';
 import { ApplicationFormPreviewModal } from '@/components/ApplicationForm/ApplicationFormPreview/ApplicationFormPreview.component';
@@ -45,6 +45,7 @@ const ApplicationFormList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
+  const generationNumber = searchParams.get('generationNumber');
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
@@ -73,8 +74,9 @@ const ApplicationFormList = () => {
       teamId: parseInt(teamId, 10) || undefined,
       searchWord,
       sort: sortParam,
+      generationNumber: parseUrlParam(generationNumber),
     }),
-    [page, size, teamId, searchWord, sortParam],
+    [page, size, teamId, searchWord, sortParam, generationNumber],
   );
 
   const [totalCount, setTotalCount] = useState(0);

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -15,10 +15,10 @@ import {
   BottomCTA,
 } from '@/components';
 import { useDirty, usePagination, useToggleState } from '@/hooks';
-import { $applicationForms, $teamIdByName } from '@/store';
+import { $applicationForms, $generationNumber, $teamIdByName } from '@/store';
 import { ApplicationFormResponse, Question, ApplicationFormRequest } from '@/types';
 import { PATH, SORT_TYPE } from '@/constants';
-import { formatDate, parseUrlParam } from '@/utils';
+import { formatDate } from '@/utils';
 import { TableColumn, SortType } from '@/components/common/Table/Table.component';
 import { TeamType, RoleType } from '@/components/common/UserProfile/UserProfile.component';
 import { ApplicationFormPreviewModal } from '@/components/ApplicationForm/ApplicationFormPreview/ApplicationFormPreview.component';
@@ -45,7 +45,7 @@ const ApplicationFormList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const teamName = searchParams.get('team');
   const teamId = useRecoilValue($teamIdByName(teamName));
-  const generationNumber = searchParams.get('generationNumber');
+  const generationNumber = useRecoilValue($generationNumber);
 
   const page = searchParams.get('page') || '1';
   const size = searchParams.get('size') || '20';
@@ -74,7 +74,7 @@ const ApplicationFormList = () => {
       teamId: parseInt(teamId, 10) || undefined,
       searchWord,
       sort: sortParam,
-      generationNumber: parseUrlParam(generationNumber),
+      generationNumber,
     }),
     [page, size, teamId, searchWord, sortParam, generationNumber],
   );

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -17,7 +17,7 @@ import {
   Table,
   TeamNavigationTabs,
 } from '@/components';
-import { formatDate, uniqArray } from '@/utils';
+import { formatDate, parseUrlParam, uniqArray } from '@/utils';
 import { PATH, SORT_TYPE } from '@/constants';
 import { $applications, $teamIdByName, ModalKey, $modalByStorage, $profile } from '@/store';
 import { useConvertToXlsx, useDirty, usePagination } from '@/hooks';
@@ -44,6 +44,7 @@ const ApplicationList = () => {
   const { pathname, search } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const teamName = searchParams.get('team');
+
   const teamId = useRecoilValue($teamIdByName(teamName));
   const myTeamName = useRecoilValue($profile)[0];
   const isMyTeam = useMemo(
@@ -60,6 +61,7 @@ const ApplicationList = () => {
   const confirmStatus = searchParams.get('confirmStatus') || '';
   const resultStatus = searchParams.get('resultStatus') || '';
   const searchWord = searchParams.get('searchWord') || '';
+  const generationNumber = searchParams.get('generationNumber');
 
   const [sortTypes, setSortTypes] = useState<SortType<ApplicationResponse>[]>([
     { accessor: 'applicant.name', type: SORT_TYPE.DEFAULT },
@@ -90,9 +92,10 @@ const ApplicationList = () => {
       confirmStatus,
       resultStatus,
       sort: sortParam,
+      generationNumber: parseUrlParam(generationNumber),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [page, size, teamId, searchWord, sortParam, confirmStatus, resultStatus],
+    [page, size, teamId, searchWord, sortParam, confirmStatus, resultStatus, generationNumber],
   );
 
   const [totalCount, setTotalCount] = useState(0);
@@ -143,6 +146,7 @@ const ApplicationList = () => {
           page: 0,
           size: tableRows.page.totalCount + APPLICATION_EXTRA_SIZE,
           teamId: parseInt(teamId, 10) || undefined,
+          generationNumber: parseUrlParam(generationNumber),
         });
         setSelectedRows(applications.data);
         if (applications.page) {

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -17,9 +17,16 @@ import {
   Table,
   TeamNavigationTabs,
 } from '@/components';
-import { formatDate, parseUrlParam, uniqArray } from '@/utils';
+import { formatDate, uniqArray } from '@/utils';
 import { PATH, SORT_TYPE } from '@/constants';
-import { $applications, $teamIdByName, ModalKey, $modalByStorage, $profile } from '@/store';
+import {
+  $applications,
+  $teamIdByName,
+  ModalKey,
+  $modalByStorage,
+  $profile,
+  $generationNumber,
+} from '@/store';
 import { useConvertToXlsx, useDirty, usePagination } from '@/hooks';
 import { ApplicationRequest, ApplicationResponse } from '@/types';
 import { SortType, TableColumn } from '@/components/common/Table/Table.component';
@@ -47,6 +54,7 @@ const ApplicationList = () => {
 
   const teamId = useRecoilValue($teamIdByName(teamName));
   const myTeamName = useRecoilValue($profile)[0];
+  const generationNumber = useRecoilValue($generationNumber);
   const isMyTeam = useMemo(
     () =>
       !teamName ||
@@ -61,7 +69,6 @@ const ApplicationList = () => {
   const confirmStatus = searchParams.get('confirmStatus') || '';
   const resultStatus = searchParams.get('resultStatus') || '';
   const searchWord = searchParams.get('searchWord') || '';
-  const generationNumber = searchParams.get('generationNumber');
 
   const [sortTypes, setSortTypes] = useState<SortType<ApplicationResponse>[]>([
     { accessor: 'applicant.name', type: SORT_TYPE.DEFAULT },
@@ -92,7 +99,7 @@ const ApplicationList = () => {
       confirmStatus,
       resultStatus,
       sort: sortParam,
-      generationNumber: parseUrlParam(generationNumber),
+      generationNumber,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [page, size, teamId, searchWord, sortParam, confirmStatus, resultStatus, generationNumber],
@@ -146,7 +153,7 @@ const ApplicationList = () => {
           page: 0,
           size: tableRows.page.totalCount + APPLICATION_EXTRA_SIZE,
           teamId: parseInt(teamId, 10) || undefined,
-          generationNumber: parseUrlParam(generationNumber),
+          generationNumber,
         });
         setSelectedRows(applications.data);
         if (applications.page) {
@@ -154,7 +161,7 @@ const ApplicationList = () => {
         }
       }
     },
-    [tableRows.page?.totalCount, teamId],
+    [tableRows.page?.totalCount, teamId, generationNumber],
   );
 
   const columns: TableColumn<ApplicationResponse>[] = [

--- a/src/pages/ApplicationList/ApplicationList.styled.ts
+++ b/src/pages/ApplicationList/ApplicationList.styled.ts
@@ -20,7 +20,7 @@ export const StickyContainer = styled.div`
   ${({ theme }) => css`
     position: sticky;
     top: 0;
-    z-index: ${theme.zIndex.select};
+    z-index: calc(${theme.zIndex.sticky} + 1);
     padding-bottom: 1.2rem;
     background-color: ${theme.colors.white};
   `}

--- a/src/store/generation.ts
+++ b/src/store/generation.ts
@@ -1,7 +1,16 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 import { GenerationResponse } from '@/types';
+
+const { persistAtom } = recoilPersist({ key: 'generationNumber', storage: sessionStorage });
 
 export const $generations = atom<GenerationResponse>({
   key: 'generations',
   default: [],
+});
+
+export const $generationNumber = atom<number | undefined>({
+  key: 'generationNumber',
+  default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/store/generation.ts
+++ b/src/store/generation.ts
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 import { GenerationResponse } from '@/types';
 
-const { persistAtom } = recoilPersist({ key: 'generationNumber', storage: sessionStorage });
+const { persistAtom } = recoilPersist({ key: 'generationNumber', storage: localStorage });
 
 export const $generations = atom<GenerationResponse>({
   key: 'generations',

--- a/src/types/dto/application.ts
+++ b/src/types/dto/application.ts
@@ -39,6 +39,7 @@ export interface ApplicationRequest {
   size?: number;
   sort?: string;
   teamId?: number;
+  generationNumber?: number;
 }
 
 export interface ApplicationResponse {

--- a/src/types/dto/applicationForm.ts
+++ b/src/types/dto/applicationForm.ts
@@ -21,6 +21,7 @@ export interface ApplicationFormRequest {
   size?: number;
   sort?: string;
   teamId?: number;
+  generationNumber?: number;
 }
 
 export interface ApplicationFormResponse {

--- a/src/types/dto/member.ts
+++ b/src/types/dto/member.ts
@@ -1,5 +1,5 @@
 export interface MemberRequest {
-  generationNumber: number;
+  generationNumber?: number;
   page?: number;
   size?: number;
   platform?: string;

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,6 +1,6 @@
 export const parseUrlParam = (param: string | null | undefined) => {
   if (param === null || param === undefined) {
-    return 0;
+    return undefined;
   }
 
   return parseInt(param, 10);

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,6 +1,6 @@
 export const parseUrlParam = (param: string | null | undefined) => {
   if (param === null || param === undefined) {
-    return undefined;
+    return 0;
   }
 
   return parseInt(param, 10);


### PR DESCRIPTION
## 변경사항

<img width="1512" alt="스크린샷 2022-12-20 오후 9 53 45" src="https://user-images.githubusercontent.com/38802280/208672431-562aab98-015f-492c-9208-a005e05ea746.png">

* 기수정보 선택해서 해당 기수의 관련된 데이터 조회하도록 추가
  * 해당 로직은 GenerationSelect해서 결정짓도록
  * 첨에 url query string으로 하다가 다른 페이지를 가거나 새로고침해도 기수정보를 유지시키기 위해 recoil-persist를 사용해서 localStorage에 넣도록 했어요
  * SMS를 제외하고 모든 페이지에 적용
* @sanoopark 코드오너 추가

-

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 프로젝트 설정(웹팩, 바벨, 린팅 등)

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)