### PR TITLE
1.2.0 qa 준비

### DIFF
--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -30,10 +30,11 @@ const navigationItems: NavigationItem[] = [
     label: '지원서 설문지 내역',
     to: PATH.APPLICATION_FORM,
   },
-  {
-    label: '활동점수',
-    to: PATH.ACTIVITY_SCORE,
-  },
+  // MEMO: (@mango906): 활동점수 QA할 때 다시 노출시키기
+  // {
+  //   label: '활동점수',
+  //   to: PATH.ACTIVITY_SCORE,
+  // },
 ];
 
 const Header = () => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,4 @@ export { default as useConvertTextToLink } from './useConvertTextToLink';
 export { default as useHistory } from './useHistory';
 export { default as usePrompt } from './usePrompt';
 export { default as useMyTeam } from './useMyTeam';
+export { default as useRefreshSelectorFamilyByKey } from './useRefreshSelectorFamilyByKey';

--- a/src/hooks/useRefreshSelectorFamilyByKey.ts
+++ b/src/hooks/useRefreshSelectorFamilyByKey.ts
@@ -1,0 +1,30 @@
+import { RecoilValue, Snapshot, useRecoilCallback } from 'recoil';
+
+const noWaitRegex = /__noWait/;
+const selectorFamilyRegex = /__selectorFamily/;
+
+const isAtom = (snapshot: Snapshot, target: RecoilValue<unknown>) => {
+  const { type } = snapshot.getInfo_UNSTABLE(target);
+  return type === 'atom';
+};
+const isNoWaitValue = ({ key }: RecoilValue<unknown>) => noWaitRegex.test(key);
+const isSelectorFamily = ({ key }: RecoilValue<unknown>) => selectorFamilyRegex.test(key);
+
+const useRefreshSelectorFamilyByKey = () =>
+  useRecoilCallback(({ snapshot, refresh }) => (selectorKey) => {
+    const nodes = Array.from(snapshot.getNodes_UNSTABLE());
+
+    nodes.forEach((node) => {
+      if (isAtom(snapshot, node) || isNoWaitValue(node) || !isSelectorFamily(node)) {
+        return;
+      }
+
+      const nodeKey = node.key.split(selectorFamilyRegex)[0];
+
+      if (selectorKey === nodeKey) {
+        refresh(node);
+      }
+    });
+  });
+
+export default useRefreshSelectorFamilyByKey;

--- a/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
+++ b/src/pages/ApplicationFormDetail/ApplicationFormDetail.page.tsx
@@ -10,7 +10,7 @@ import { ParamId, Question, QuestionKind } from '@/types';
 import { $applicationFormDetail } from '@/store/applicationForm';
 import { InputSize } from '@/components/common/Input/Input.component';
 import * as api from '@/api';
-import { useToast, useUnmount } from '@/hooks';
+import { useRefreshSelectorFamilyByKey, useToast, useUnmount } from '@/hooks';
 import { request } from '@/utils';
 import { PATH } from '@/constants';
 import { $modalByStorage, ModalKey } from '@/store';
@@ -26,6 +26,7 @@ const ApplicationFormDetail = () => {
 
   const navigate = useNavigate();
   const { handleAddToast } = useToast();
+  const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
 
   const [{ questions, name, team, createdAt, createdBy, updatedAt, updatedBy }] = useRecoilState(
     $applicationFormDetail({ id: id ?? '' }),
@@ -60,6 +61,7 @@ const ApplicationFormDetail = () => {
                 message: '성공적으로 지원서 설문지를 삭제했습니다.',
               });
 
+              refreshSelectorFamilyByKey('applicationForms');
               navigate(PATH.APPLICATION_FORM);
             },
             onCompleted: () => {

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -166,6 +166,12 @@ const ApplicationFormList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
+  useEffect(() => {
+    searchParams.delete('page');
+    setSearchParams(searchParams);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generationNumber]);
+
   useLayoutEffect(() => {
     if (isDirty && !isLoading) {
       window.scrollTo({ top: 179, left: 0, behavior: 'smooth' });

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -299,6 +299,12 @@ const ApplicationList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
+  useEffect(() => {
+    searchParams.delete('page');
+    setSearchParams(searchParams);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generationNumber]);
+
   useLayoutEffect(() => {
     if (isDirty && !isLoading) {
       window.scrollTo({ top: 179, left: 0, behavior: 'smooth' });

--- a/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
+++ b/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, useFormState } from 'react-hook-form';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { ApplicationFormAside, ApplicationFormSection } from '@/components';
+import { ApplicationFormAside, ApplicationFormSection, Blocker } from '@/components';
 import * as Styled from './CreateApplicationForm.styled';
 
 import { Question, QuestionKind } from '@/types/dto/applicationForm';
@@ -42,7 +42,9 @@ const CreateApplicationForm = () => {
     },
   });
 
-  const { register, handleSubmit, setValue, formState } = methods;
+  const { register, handleSubmit, setValue, control, formState } = methods;
+
+  const { isDirty, isSubmitSuccessful } = useFormState({ control });
 
   const navigate = useNavigate();
 
@@ -126,31 +128,34 @@ const CreateApplicationForm = () => {
   }, [formState.errors.teamId]);
 
   return (
-    <FormProvider {...methods}>
-      <Styled.ApplicationFormControlPage>
-        <ApplicationFormSection headline="지원서 설문지 작성" />
-        <form onSubmit={handleSubmit(handleSubmitForm)}>
-          <article>
-            <ApplicationFormTemplate />
-          </article>
-          <ApplicationFormAside
-            createdAt={current}
-            platform={
-              <Styled.TeamSelect
-                placeholder="플랫폼 선택"
-                size={SelectSize.sm}
-                options={teamOptions}
-                onChangeOption={(option) => setValue('teamId', Number(option.value))}
-                {...register(`teamId`, { required: true })}
-              />
-            }
-            createdBy={position}
-            leftActionButton={{ text: '취소', onClick: () => navigate(-1), isLoading }}
-            rightActionButton={{ text: '저장', type: 'submit' }}
-          />
-        </form>
-      </Styled.ApplicationFormControlPage>
-    </FormProvider>
+    <>
+      <FormProvider {...methods}>
+        <Styled.ApplicationFormControlPage>
+          <ApplicationFormSection headline="지원서 설문지 작성" />
+          <form onSubmit={handleSubmit(handleSubmitForm)}>
+            <article>
+              <ApplicationFormTemplate />
+            </article>
+            <ApplicationFormAside
+              createdAt={current}
+              platform={
+                <Styled.TeamSelect
+                  placeholder="플랫폼 선택"
+                  size={SelectSize.sm}
+                  options={teamOptions}
+                  onChangeOption={(option) => setValue('teamId', Number(option.value))}
+                  {...register(`teamId`, { required: true })}
+                />
+              }
+              createdBy={position}
+              leftActionButton={{ text: '취소', onClick: () => navigate(-1), isLoading }}
+              rightActionButton={{ text: '저장', type: 'submit' }}
+            />
+          </form>
+        </Styled.ApplicationFormControlPage>
+      </FormProvider>
+      <Blocker isBlocking={isDirty && !isSubmitSuccessful} />
+    </>
   );
 };
 

--- a/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
+++ b/src/pages/CreateApplicationForm/CreateApplicationForm.page.tsx
@@ -10,7 +10,7 @@ import * as api from '@/api';
 import { $modalByStorage, $profile, $teams, ModalKey } from '@/store';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import ApplicationFormTemplate from '@/components/ApplicationForm/ApplicationFormTemplate/ApplicationFormTemplate.component';
-import { useToast } from '@/hooks';
+import { useRefreshSelectorFamilyByKey, useToast } from '@/hooks';
 
 import { request } from '@/utils';
 import { ToastType } from '@/components/common/Toast/Toast.component';
@@ -58,6 +58,7 @@ const CreateApplicationForm = () => {
   );
 
   const { handleAddToast } = useToast();
+  const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
 
   const handleSubmitForm = useRecoilCallback(({ set }) => async (data: FormValues) => {
     if (data.questions.length === 0) {
@@ -96,6 +97,7 @@ const CreateApplicationForm = () => {
                 message: '성공적으로 지원서 설문지를 작성했습니다.',
               });
 
+              refreshSelectorFamilyByKey('applicationForms');
               navigate(getApplicationFormDetailPage(applicationFormId));
             },
             onCompleted: () => {

--- a/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
+++ b/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
@@ -41,7 +41,7 @@ const UpdateApplicationForm = () => {
 
   const { handleSubmit, control } = methods;
 
-  const { isDirty } = useFormState({ control });
+  const { isDirty, isSubmitSuccessful } = useFormState({ control });
 
   const { handleAddToast } = useToast();
   const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
@@ -125,7 +125,7 @@ const UpdateApplicationForm = () => {
           </form>
         </Styled.UpdateApplicationFormPage>
       </FormProvider>
-      <Blocker isBlocking={isDirty} />
+      <Blocker isBlocking={isDirty && !isSubmitSuccessful} />
     </>
   );
 };

--- a/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
+++ b/src/pages/UpdateApplicationForm/UpdateApplicationForm.page.tsx
@@ -9,7 +9,7 @@ import { ApplicationFormAside, ApplicationFormSection, Blocker } from '@/compone
 import ApplicationFormTemplate from '@/components/ApplicationForm/ApplicationFormTemplate/ApplicationFormTemplate.component';
 import * as api from '@/api';
 import { request } from '@/utils';
-import { useHistory, useToast, useUnmount } from '@/hooks';
+import { useHistory, useRefreshSelectorFamilyByKey, useToast, useUnmount } from '@/hooks';
 import { ToastType } from '@/components/common/Toast/Toast.component';
 import { getApplicationFormDetailPage, PATH } from '@/constants';
 
@@ -44,6 +44,7 @@ const UpdateApplicationForm = () => {
   const { isDirty } = useFormState({ control });
 
   const { handleAddToast } = useToast();
+  const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
 
   const handleSubmitForm = useRecoilCallback(({ set }) => async (data: FormValues) => {
     if (!id) {
@@ -79,6 +80,7 @@ const UpdateApplicationForm = () => {
                 message: '성공적으로 지원서 설문지를 수정했습니다.',
               });
 
+              refreshSelectorFamilyByKey('applicationForms');
               navigate(getApplicationFormDetailPage(id));
             },
             onCompleted: () => {


### PR DESCRIPTION
## 변경사항

- 지원서, 지원서 설문지 내역에서 기수정보 변경할 때 페이징 정보 초기화
- 활동점수 페이지 노출 비활성화
  - 이번 QA 범위가 아니라 나중에 노출
- useRefreshSelectorFamilyByKey 훅 추가
  - 추가, 수정 삭제 시에 내역에 해당하는 selector를 초기화 해야하는데 다른 페이지에선 이미 할당된 selector에 필요한 param을 가지고 있찌 않아서 selectorKey로 리셋시키는 훅
- 지원서 설문지 추가,수정,삭제 후 지원서 설문지 갱신되지 않는 이슈 수정
- 지원서 설문지 수정 후 상새 내역으로 이동할 때 Blocker에 가로막히는 이슈 수정
  - Blocker는 페이지를 이탈하시겠습니까? 모달로 생각하면 됨
- 지원서 설문지 추가페이지에도 Blocker 컴포넌트 추가



### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)