### PR TITLE
Qa Release/v1.2.0 - 2차

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,8 +56,10 @@ const App = () => {
 
     try {
       if (!isAuthorizedSnapshot && !!TOKEN) {
-        const { data: me } = await api.getMyInfo();
-        const { data: generations } = await api.getGenerations();
+        const [{ data: me }, { data: generations }] = await Promise.all([
+          api.getMyInfo(),
+          api.getGenerations(),
+        ]);
 
         set($me, { accessToken: TOKEN as string, adminMember: me });
         set($generations, generations);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Suspense } from 'react';
+import React, { ReactNode, Suspense, useEffect } from 'react';
 import { Routes, Route, Navigate, NavigateProps, useNavigate } from 'react-router-dom';
 import { Global, ThemeProvider } from '@emotion/react';
 import { useRecoilValue, useRecoilCallback } from 'recoil';
@@ -6,7 +6,7 @@ import { ModalViewer, Layout, Toast } from '@/components';
 
 import { theme, globalStyles } from './styles';
 
-import { $me, $isAuthorized, $teams, $toast, $generations } from './store';
+import { $me, $isAuthorized, $teams, $toast, $generations, $generationNumber } from './store';
 import * as api from './api';
 import { ACCESS_TOKEN, PATH } from './constants';
 
@@ -43,6 +43,13 @@ const App = () => {
   const TOKEN = localStorage.getItem(ACCESS_TOKEN);
   const isAuthorized = useRecoilValue($isAuthorized) || !!TOKEN;
   const toast = useRecoilValue($toast);
+  const generationNumber = useRecoilValue($generationNumber);
+
+  const getTeams = useRecoilCallback(({ set }) => async () => {
+    const { data: teams } = await api.getTeams(generationNumber);
+
+    set($teams, teams);
+  });
 
   useRecoilCallback(({ snapshot, set, reset }) => async () => {
     const isAuthorizedSnapshot = snapshot.getLoadable($isAuthorized).contents;
@@ -50,11 +57,9 @@ const App = () => {
     try {
       if (!isAuthorizedSnapshot && !!TOKEN) {
         const { data: me } = await api.getMyInfo();
-        const { data: teams } = await api.getTeams();
         const { data: generations } = await api.getGenerations();
 
         set($me, { accessToken: TOKEN as string, adminMember: me });
-        set($teams, teams);
         set($generations, generations);
       }
     } catch (e) {
@@ -63,6 +68,11 @@ const App = () => {
       navigate(PATH.LOGIN);
     }
   })();
+
+  useEffect(() => {
+    getTeams();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generationNumber]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -1,7 +1,8 @@
 import { BaseResponse, TeamResponse } from '@/types';
 import http from '@/api/core';
 
-export const getTeams = (): Promise<BaseResponse<TeamResponse>> =>
+export const getTeams = (generationNumber?: number): Promise<BaseResponse<TeamResponse>> =>
   http.get({
     url: '/teams',
+    params: { generationNumber },
   });

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -15,12 +15,7 @@ import ApplicationStatusBadge, {
   ApplicationResultStatusKeyType,
   ApplicationResultStatusType,
 } from '@/components/common/ApplicationStatusBadge/ApplicationStatusBadge.component';
-import {
-  toUtcWithoutChangingTime,
-  formatDate,
-  getRecruitingProgressStatusFromRecruitingPeriod,
-  RecruitingProgressStatus,
-} from '@/utils/date';
+import { toUtcWithoutChangingTime, formatDate } from '@/utils/date';
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
 import { useOnClickOutSide, useToast } from '@/hooks';
 import { rangeArray, request } from '@/utils';
@@ -294,20 +289,6 @@ const ApplicationPanel = ({
         if (applicationResultStatus !== ApplicationResultStatusInDto.SCREENING_PASSED) {
           delete requestDto.interviewStartedAt;
           delete requestDto.interviewEndedAt;
-        }
-
-        const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(
-          new Date(),
-        );
-
-        if (
-          recruitingProgressStatus === RecruitingProgressStatus.PREVIOUS ||
-          recruitingProgressStatus === RecruitingProgressStatus.AFTER_FIRST_SEMINAR
-        ) {
-          return handleAddToast({
-            type: ToastType.error,
-            message: '변경 기간이 아닙니다.',
-          });
         }
 
         request({

--- a/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
+++ b/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
@@ -1,11 +1,7 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useRecoilCallback } from 'recoil';
 import { useForm } from 'react-hook-form';
-import {
-  getRecruitingProgressStatusFromRecruitingPeriod,
-  RecruitingProgressStatus,
-  request,
-} from '@/utils';
+import { request } from '@/utils';
 import { ModalWrapper, SelectField, TitleWithContent } from '@/components';
 import * as Styled from './ChangeResultModalDialog.styled';
 import * as api from '@/api';
@@ -54,21 +50,7 @@ const ChangeResultModalDialog = ({
   const handleSendSms = useRecoilCallback(
     ({ set, refresh }) =>
       async ({ applicationResultStatus }: FormValues) => {
-        const recruitingProgressStatus = getRecruitingProgressStatusFromRecruitingPeriod(
-          new Date(),
-        );
-
-        if (
-          recruitingProgressStatus === RecruitingProgressStatus.PREVIOUS ||
-          recruitingProgressStatus === RecruitingProgressStatus.AFTER_FIRST_SEMINAR
-        ) {
-          return handleAddToast({
-            type: ToastType.error,
-            message: '변경 기간이 아닙니다.',
-          });
-        }
-
-        await set($modalByStorage(ModalKey.alertModalDialog), {
+        set($modalByStorage(ModalKey.alertModalDialog), {
           key: ModalKey.alertModalDialog,
           isOpen: true,
           props: {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import { ValueOf } from '@/types';
 import 'dayjs/locale/ko';
 
 dayjs.locale('ko');
@@ -19,61 +18,4 @@ export const formatDate = (date: string | Date, format: DateFormat) => {
 
 export const toUtcWithoutChangingTime = (date: string | Date) => {
   return dayjs(date).utc(true).format().replace('Z', '');
-};
-
-const [
-  RECRUITMENT_START_KST_DATE, // 서류 접수 시작
-  RECRUITMENT_END_KST_DATE, // 서류 접수 종료
-  SCREENING_RESULT_ANNOUNCED_KST_DATE, // 서류 결과 발표
-  INTERVIEW_RESULT_ANNOUNCED_KST_DATE, // 최종 합격 발표
-  AFTER_FIRST_SEMINAR_JOIN_KST_DATE, // 첫번째 세미나 끝나는 시각
-] = [
-  dayjs('2022-03-16T00:00:00+09:00'),
-  dayjs('2022-03-29T23:59:59+09:00'),
-  dayjs('2022-04-03T10:00:00+09:00'),
-  dayjs('2022-04-12T10:00:00+09:00'),
-  dayjs('2022-04-16T17:00:00+09:00'),
-];
-
-export const RecruitingProgressStatus = {
-  PREVIOUS: 'PREVIOUS',
-  IN_RECRUITING: 'IN_RECRUITING',
-  END_RECRUITING: 'END_RECRUITING',
-  AFTER_SCREENING_ANNOUNCED: 'AFTER_SCREENING_ANNOUNCED', // 지원 현황 서류 검토 -> 서류 결과 발표
-  AFTER_INTERVIEWING_ANNOUNCED: 'AFTER_INTERVIEWING_ANNOUNCED', // 지원 현황 서류 결과 발표 -> 최종 합격 발표
-  AFTER_FIRST_SEMINAR: 'AFTER_FIRST_SEMINAR', // 지원 현황 결과 발표 숨김
-  INVALID: 'INVALID',
-} as const;
-
-export type RecruitingProgressStatusValueType = ValueOf<typeof RecruitingProgressStatus>;
-
-export const getRecruitingProgressStatusFromRecruitingPeriod = (
-  date: Date,
-): RecruitingProgressStatusValueType => {
-  const currentDate = dayjs(date);
-  if (currentDate < RECRUITMENT_START_KST_DATE) {
-    return RecruitingProgressStatus.PREVIOUS;
-  }
-  if (RECRUITMENT_START_KST_DATE <= currentDate && currentDate <= RECRUITMENT_END_KST_DATE) {
-    return RecruitingProgressStatus.IN_RECRUITING;
-  }
-  if (RECRUITMENT_END_KST_DATE < currentDate && currentDate < SCREENING_RESULT_ANNOUNCED_KST_DATE) {
-    return RecruitingProgressStatus.END_RECRUITING;
-  }
-  if (
-    SCREENING_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
-    currentDate < INTERVIEW_RESULT_ANNOUNCED_KST_DATE
-  ) {
-    return RecruitingProgressStatus.AFTER_SCREENING_ANNOUNCED;
-  }
-  if (
-    INTERVIEW_RESULT_ANNOUNCED_KST_DATE <= currentDate &&
-    currentDate < AFTER_FIRST_SEMINAR_JOIN_KST_DATE
-  ) {
-    return RecruitingProgressStatus.AFTER_INTERVIEWING_ANNOUNCED;
-  }
-  if (AFTER_FIRST_SEMINAR_JOIN_KST_DATE <= currentDate) {
-    return RecruitingProgressStatus.AFTER_FIRST_SEMINAR;
-  }
-  return RecruitingProgressStatus.INVALID;
 };


### PR DESCRIPTION
## 변경사항

- 지원서 합격 여부 변경할 수 없는 이슈 수정
  - 날짜 로직이 12기 지원에 맞춰져 있어서 삭제
  - 날짜 검증 로직이 필요없을거 같아 삭제
- 최신기수 아닐 경우 지원서 필터 걸리지 않는 이슈 수정
  - 지원서 필터의 teamId가 기수별로 다른데 무조건 최신 기수로 가서 조회가 안됨
  - useEffect를 써서 해결했는데 더 좋은 방법이 있다면 추천해주셔도 됩니당 (맘에 안들어요 ㅠ)

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)