### PR TITLE
스케줄 정보 목록 UI 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   ActivityScoreList,
   ActivityScoreDetail,
   ErrorPage,
+  ScheduleList,
 } from './pages';
 
 interface RequiredAuthProps extends Partial<NavigateProps> {
@@ -156,6 +157,14 @@ const App = () => {
               element={
                 <RequiredAuth isAuth={isAuthorized}>
                   <ActivityScoreDetail />
+                </RequiredAuth>
+              }
+            />
+            <Route
+              path={PATH.SCHEDULE}
+              element={
+                <RequiredAuth isAuth={isAuthorized}>
+                  <ScheduleList />
                 </RequiredAuth>
               }
             />

--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -34,6 +34,10 @@ const navigationItems: NavigationItem[] = [
     label: '활동점수',
     to: PATH.ACTIVITY_SCORE,
   },
+  {
+    label: '스케쥴 정보',
+    to: PATH.SCHEDULE,
+  },
 ];
 
 const Header = () => {

--- a/src/components/common/Header/Header.component.tsx
+++ b/src/components/common/Header/Header.component.tsx
@@ -30,11 +30,10 @@ const navigationItems: NavigationItem[] = [
     label: '지원서 설문지 내역',
     to: PATH.APPLICATION_FORM,
   },
-  // MEMO: (@mango906): 활동점수 QA할 때 다시 노출시키기
-  // {
-  //   label: '활동점수',
-  //   to: PATH.ACTIVITY_SCORE,
-  // },
+  {
+    label: '활동점수',
+    to: PATH.ACTIVITY_SCORE,
+  },
 ];
 
 const Header = () => {

--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -18,9 +18,13 @@ const Layout = () => {
 
   const isListPage = useMemo(
     () =>
-      [PATH.APPLICATION, PATH.APPLICATION_FORM, PATH.ACTIVITY_SCORE].some(
-        (each) => pathname === each,
-      ),
+      [
+        PATH.APPLICATION,
+        PATH.APPLICATION_FORM,
+        PATH.ACTIVITY_SCORE,
+        PATH.ACTIVITY_SCORE,
+        PATH.SCHEDULE,
+      ].some((each) => pathname === each),
     [pathname],
   );
 

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -11,6 +11,7 @@ export const PATH = {
   APPLICATION_FORM_UPDATE: '/application-form/update/:id',
   ACTIVITY_SCORE: '/activity-score',
   ACTIVITY_SCORE_DETAIL: '/activity-score/:generationNumber/:memberId',
+  SCHEDULE: '/schedule',
   NOT_FOUND: '/404',
   FORBIDDEN: '/403',
 } as const;

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -12,6 +12,7 @@ export const PATH = {
   ACTIVITY_SCORE: '/activity-score',
   ACTIVITY_SCORE_DETAIL: '/activity-score/:generationNumber/:memberId',
   SCHEDULE: '/schedule',
+  SCHEDULE_CREATE: '/schedule/create',
   NOT_FOUND: '/404',
   FORBIDDEN: '/403',
 } as const;

--- a/src/pages/ScheduleList/ScheduleList.page.tsx
+++ b/src/pages/ScheduleList/ScheduleList.page.tsx
@@ -1,7 +1,113 @@
 import React from 'react';
+import { BottomCTA, Button, Link, Pagination, SearchOptionBar, Table } from '@/components';
+import * as Styled from './ScheduleList.styled';
+import { TableColumn } from '@/components/common/Table/Table.component';
+import { ScheduleResponse, ScheduleStatus } from '@/types/dto/schedule';
+import { formatDate } from '@/utils/date';
+import { PATH } from '@/constants';
+import { ButtonShape, ButtonSize } from '@/components/common/Button/Button.component';
+import { usePagination } from '@/hooks';
+
+const rows: ScheduleResponse[] = [
+  {
+    name: '스케줄 명',
+    endedAt: '2023-01-15',
+    eventList: [],
+    generationNumber: 13,
+    scheduleId: 1,
+    startedAt: '2023-01-15',
+    status: ScheduleStatus.ADMIN_ONLY,
+  },
+];
+
+const totalCount = rows.length;
 
 const ScheduleList = () => {
-  return <>schedule list</>;
+  const columns: TableColumn<ScheduleResponse>[] = [
+    {
+      title: '스케줄 명',
+      accessor: 'name',
+      widthRatio: '20%',
+    },
+    {
+      title: '스케줄 일시',
+      accessor: 'name',
+      widthRatio: '20%',
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+    },
+    {
+      title: '등록 일시',
+      accessor: 'name',
+      widthRatio: '20%',
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+    },
+    {
+      title: '배포 일시',
+      accessor: 'name',
+      widthRatio: '20%',
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+    },
+    {
+      title: '배포 상태',
+      accessor: 'name',
+      widthRatio: '20%',
+    },
+  ];
+
+  const { pageOptions, handleChangePage, handleChangeSize } = usePagination({
+    totalCount: rows.length,
+  });
+
+  return (
+    <Styled.PageWrapper>
+      <Styled.Heading>스케줄 정보 </Styled.Heading>
+      <Styled.StickyContainer>
+        <SearchOptionBar placeholder="스케줄명 검색" />
+      </Styled.StickyContainer>
+      <Table
+        prefix="schedule"
+        topStickyHeight={14.1}
+        columns={columns}
+        rows={rows}
+        supportBar={{
+          totalCount,
+          totalSummaryText: '총 지원설문지',
+          buttons: [
+            <Link to={PATH.SCHEDULE_CREATE}>
+              <Button $size={ButtonSize.xs} shape={ButtonShape.defaultLine}>
+                스케줄 추가
+              </Button>
+            </Link>,
+          ],
+        }}
+        pagination={
+          <Pagination
+            pageOptions={pageOptions}
+            selectableSize={{
+              selectBoxPosition: rows.length > 3 ? 'top' : 'bottom',
+              handleChangeSize,
+            }}
+            handleChangePage={handleChangePage}
+          />
+        }
+      />
+      <BottomCTA
+        boundaries={{
+          visibility: { topHeight: 179, bottomHeight: 20 },
+          noAnimation: { bottomHeight: 20 },
+        }}
+      >
+        <Pagination
+          pageOptions={pageOptions}
+          selectableSize={{
+            selectBoxPosition: rows.length > 3 ? 'top' : 'bottom',
+            handleChangeSize,
+          }}
+          handleChangePage={handleChangePage}
+        />
+      </BottomCTA>
+    </Styled.PageWrapper>
+  );
 };
 
 export default ScheduleList;

--- a/src/pages/ScheduleList/ScheduleList.page.tsx
+++ b/src/pages/ScheduleList/ScheduleList.page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ScheduleList = () => {
+  return <>schedule list</>;
+};
+
+export default ScheduleList;

--- a/src/pages/ScheduleList/ScheduleList.styled.ts
+++ b/src/pages/ScheduleList/ScheduleList.styled.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const PageWrapper = styled.div`
+  padding: 4rem 0;
+`;
+
+export const Heading = styled.h2`
+  ${({ theme }) => css`
+    margin-bottom: 2.4rem;
+    color: ${theme.colors.gray80};
+    font-weight: 700;
+    font-size: 3.6rem;
+    line-height: 4.5rem;
+  `};
+`;
+
+export const StickyContainer = styled.div`
+  ${({ theme }) => css`
+    position: sticky;
+    top: 0;
+    z-index: ${theme.zIndex.sticky};
+    padding-bottom: 1.2rem;
+    background-color: ${theme.colors.white};
+  `}
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -9,3 +9,4 @@ export { default as EmailSendingList } from './EmailSendingList/EmailSendingList
 export { default as ErrorPage } from './ErrorPage/ErrorPage.page';
 export { default as ActivityScoreList } from './ActivityScoreList/ActivityScoreList.page';
 export { default as ActivityScoreDetail } from './ActivityScoreDetail/ActivityScoreDetail.page';
+export { default as ScheduleList } from './ScheduleList/ScheduleList.page';

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -11,6 +11,20 @@ export interface ScheduleResponse {
   name: string;
   scheduleId: number;
   startedAt: string;
-  eventList: any[];
+  eventList: Event[];
   status: ValueOf<typeof ScheduleStatus>;
+}
+
+interface Event {
+  contentList: Content[];
+  endedAt: string;
+  eventId: number;
+  startedAt: string;
+}
+
+export interface Content {
+  content: string;
+  contentId: number;
+  startedAt: string;
+  title: string;
 }

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -1,0 +1,16 @@
+import { ValueOf } from '..';
+
+export const ScheduleStatus = {
+  ADMIN_ONLY: 'ADMIN_ONLY',
+  PUBLIC: 'PUBLIC',
+} as const;
+
+export interface ScheduleResponse {
+  endedAt: string;
+  generationNumber: number;
+  name: string;
+  scheduleId: number;
+  startedAt: string;
+  eventList: any[];
+  status: ValueOf<typeof ScheduleStatus>;
+}


### PR DESCRIPTION
## 변경사항

<img width="2554" alt="image" src="https://user-images.githubusercontent.com/38802280/212532296-1923cbfd-353a-4ebc-a023-f17746a44127.png">

- 활동점수 네비게이션에서 다시 노출
- 스케줄 정보 목록 UI 추가
  - api 연동은 여기서 하지 않았지만 어차피 rows가 dto기반으로 생성될거라 response dto만 생성해주었어요.
- 스케줄은 qa를 완성되기 전까지 qa를 하지 않기 때문에 develop 대신 별도의 브랜치 feat/schedule로 머지합니다.

### 작업 유형

- 신규 기능 추가


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)