### PR TITLE
스케줄 목록 api 연동

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './email';
 export * from './generation';
 export * from './member';
 export * from './scoreHistory';
+export * from './schedule';

--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,0 +1,9 @@
+import { BaseResponse } from '@/types';
+import http from '@/api/core';
+import { ScheduleRequest, ScheduleResponse } from '@/types/dto/schedule';
+
+export const getSchedules = (params: ScheduleRequest): Promise<BaseResponse<ScheduleResponse[]>> =>
+  http.get({
+    url: '/schedules',
+    params,
+  });

--- a/src/pages/ScheduleList/ScheduleList.page.tsx
+++ b/src/pages/ScheduleList/ScheduleList.page.tsx
@@ -12,6 +12,7 @@ import { usePagination } from '@/hooks';
 import { $generationNumber } from '@/store';
 import { $schedules } from '@/store/schedule';
 import { ValueOf } from '@/types';
+import { parsePlaceholderWhenInvalidDate } from '@/utils';
 
 const ScheduleList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -21,7 +22,6 @@ const ScheduleList = () => {
   const size = searchParams.get('size') || '20';
   const searchWord = searchParams.get('searchWord') || '';
 
-  // TODO(@mango906): 서버 응답에 등록 일시, 배포 일시 생기면 accessor 변경해주기
   const columns: TableColumn<ScheduleResponse>[] = [
     {
       title: '스케줄 명',
@@ -36,15 +36,21 @@ const ScheduleList = () => {
     },
     {
       title: '등록 일시',
-      accessor: 'startedAt',
+      accessor: 'createdAt',
       widthRatio: '20%',
-      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+      renderCustomCell: (cellValue) =>
+        parsePlaceholderWhenInvalidDate(
+          formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+        ),
     },
     {
       title: '배포 일시',
-      accessor: 'startedAt',
+      accessor: 'publishedAt',
       widthRatio: '20%',
-      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+      renderCustomCell: (cellValue) =>
+        parsePlaceholderWhenInvalidDate(
+          formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
+        ),
     },
     {
       title: '배포 상태',

--- a/src/pages/ScheduleList/ScheduleList.page.tsx
+++ b/src/pages/ScheduleList/ScheduleList.page.tsx
@@ -12,7 +12,6 @@ import { usePagination } from '@/hooks';
 import { $generationNumber } from '@/store';
 import { $schedules } from '@/store/schedule';
 import { ValueOf } from '@/types';
-import { parsePlaceholderWhenInvalidDate } from '@/utils';
 
 const ScheduleList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -38,19 +37,13 @@ const ScheduleList = () => {
       title: '등록 일시',
       accessor: 'createdAt',
       widthRatio: '20%',
-      renderCustomCell: (cellValue) =>
-        parsePlaceholderWhenInvalidDate(
-          formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
-        ),
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
     },
     {
       title: '배포 일시',
       accessor: 'publishedAt',
       widthRatio: '20%',
-      renderCustomCell: (cellValue) =>
-        parsePlaceholderWhenInvalidDate(
-          formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
-        ),
+      renderCustomCell: (cellValue) => formatDate(cellValue as string, 'YYYY년 M월 D일 A h시 m분'),
     },
     {
       title: '배포 상태',

--- a/src/store/schedule.ts
+++ b/src/store/schedule.ts
@@ -1,0 +1,16 @@
+import { BaseResponse } from '@/types';
+import { ScheduleRequest, ScheduleResponse } from '@/types/dto/schedule';
+import { selectorFamilyWithRefresher } from './recoil';
+
+import * as api from '@/api';
+
+export const $schedules = selectorFamilyWithRefresher<
+  BaseResponse<ScheduleResponse[]>,
+  ScheduleRequest
+>({
+  key: 'schedules',
+  get: (params) => async () => {
+    const data = await api.getSchedules(params);
+    return data;
+  },
+});

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -5,6 +5,13 @@ export const ScheduleStatus = {
   PUBLIC: 'PUBLIC',
 } as const;
 
+export interface ScheduleRequest {
+  generationNumber?: number;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
 export interface ScheduleResponse {
   endedAt: string;
   generationNumber: number;

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -17,7 +17,9 @@ export interface ScheduleResponse {
   generationNumber: number;
   name: string;
   scheduleId: number;
+  createdAt: string;
   startedAt: string;
+  publishedAt?: string;
   eventList: Event[];
   status: ValueOf<typeof ScheduleStatus>;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
+import { parsePlaceholderWhenInvalidDate } from '.';
 
 dayjs.locale('ko');
 
@@ -13,7 +14,7 @@ type DateFormat =
   | 'YYYY년 M월 D일 hh시 mm분';
 
 export const formatDate = (date: string | Date, format: DateFormat) => {
-  return dayjs(date).format(format);
+  return parsePlaceholderWhenInvalidDate(dayjs(date).format(format));
 };
 
 export const toUtcWithoutChangingTime = (date: string | Date) => {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -18,3 +18,14 @@ export const parsePlaceholderWhenEmpty = (value: string | null | undefined, pars
 
   return value;
 };
+
+export const parsePlaceholderWhenInvalidDate = (
+  value: string | null | undefined,
+  parsingText = '-',
+) => {
+  if (!value || value === 'Invalid Date') {
+    return parsingText;
+  }
+
+  return value;
+};


### PR DESCRIPTION
## 변경사항

- 스케줄 목록 api 추가
- 스케줄 정보 api 연동
  - 지금 서버에서 주는 응답에 등록 일시, 배포 일시 필드는 없어 임시로 스케줄 일시를 넣어두었고 만약 추가되면 변경할 예정입니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)