### PR TITLE
스케줄 생성 UI 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
   ActivityScoreDetail,
   ErrorPage,
   ScheduleList,
+  CreateSchedule,
 } from './pages';
 
 interface RequiredAuthProps extends Partial<NavigateProps> {
@@ -165,6 +166,14 @@ const App = () => {
               element={
                 <RequiredAuth isAuth={isAuthorized}>
                   <ScheduleList />
+                </RequiredAuth>
+              }
+            />
+            <Route
+              path={PATH.SCHEDULE_CREATE}
+              element={
+                <RequiredAuth isAuth={isAuthorized}>
+                  <CreateSchedule />
                 </RequiredAuth>
               }
             />

--- a/src/assets/svg/time-16.svg
+++ b/src/assets/svg/time-16.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="4.5" stroke="#ADB5BD" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 6.5V8.5H10" stroke="#ADB5BD" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
+++ b/src/components/ApplicationDetail/ApplicationPanel/ApplicationPanel.component.tsx
@@ -4,7 +4,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useRecoilCallback } from 'recoil';
 import utc from 'dayjs/plugin/utc';
 import { useLocation } from 'react-router-dom';
-import { Button, DatePicker, Select, SelectField } from '@/components';
+import { Button, DatePicker, Select } from '@/components';
 import * as Styled from './ApplicationPanel.styled';
 import { ButtonShape, ButtonSize } from '@/components/common/Button/Button.component';
 import { TitleWithContent } from '..';
@@ -161,7 +161,7 @@ const ControlArea = ({
     return (
       <>
         <TitleWithContent title="합격 여부" isActive>
-          <SelectField
+          <Select
             size={SelectSize.md}
             options={applicationResultOptions}
             isFullWidth

--- a/src/components/Schedule/ContentTemplate/ContentTemplate.component.tsx
+++ b/src/components/Schedule/ContentTemplate/ContentTemplate.component.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { getReadableIndex } from '@/utils';
+import * as Styled from './ContentTemplate.styled';
+import { InputField } from '@/components';
+import Time from '@/assets/svg/time-16.svg';
+import TrashCan from '@/assets/svg/trash-can-36.svg';
+
+interface ContentTemplateProps {
+  name: string;
+  index: number;
+  onRemove: (index: number) => void;
+}
+
+const ContentTemplate = ({ name, index, onRemove }: ContentTemplateProps) => {
+  const { register } = useFormContext();
+
+  const handleRemoveContent = () => onRemove(index);
+
+  return (
+    <Styled.ContentTemplateContainer>
+      <Styled.ContentTemplateWrapper>
+        <Styled.ContentTemplateTitleWrapper>
+          <Styled.ContentTemplateIndex>{getReadableIndex(index)}&#46;</Styled.ContentTemplateIndex>
+          <InputField
+            $size="md"
+            placeholder="콘텐츠 제목을 입력해주세요"
+            {...register(`${name}.${index}.title`)}
+          />
+        </Styled.ContentTemplateTitleWrapper>
+        <InputField
+          $size="sm"
+          placeholder="설명을 입력해주세요(선택사항입니다.)"
+          {...register(`${name}.${index}.desc`)}
+        />
+        <Styled.StartedAtInputField
+          $size="md"
+          placeholder="13:00"
+          endIcon={<Time />}
+          {...register(`${name}.${index}.startedAt`)}
+        />
+      </Styled.ContentTemplateWrapper>
+      <Styled.RemoveIcon type="button" onClick={handleRemoveContent}>
+        <TrashCan />
+      </Styled.RemoveIcon>
+    </Styled.ContentTemplateContainer>
+  );
+};
+
+export default ContentTemplate;

--- a/src/components/Schedule/ContentTemplate/ContentTemplate.styled.ts
+++ b/src/components/Schedule/ContentTemplate/ContentTemplate.styled.ts
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { InputField } from '@/components';
+
+export const ContentTemplateContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  padding: 2.4rem 1.2rem 2.4rem 2.4rem;
+`;
+
+export const ContentTemplateWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
+
+export const ContentTemplateIndex = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.regular16};
+  `}
+`;
+
+export const ContentTemplateTitleWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+`;
+
+export const StartedAtInputField = styled(InputField)`
+  width: 16rem;
+`;
+
+export const RemoveIcon = styled.button`
+  background-color: transparent;
+`;

--- a/src/components/Schedule/ContentTemplate/index.ts
+++ b/src/components/Schedule/ContentTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as ContentTemplate } from './ContentTemplate.component';

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
@@ -1,21 +1,36 @@
 import React, { useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import { DatePickerField, InputField, SelectField } from '@/components';
 import { InputSize } from '@/components/common/Input/Input.component';
 import * as Styled from './ScheduleTemplate.styled';
 import { $generations } from '@/store';
 import { SelectOption } from '@/components/common/Select/Select.component';
+import { SessionTemplate } from '../SessionTemplate';
+import Plus from '@/assets/svg/plus-20.svg';
+import { Session } from '@/types';
 
 interface FormValues {
   name: string;
   generationNumber: number;
   date: string;
+  sessions: Session[];
 }
 
+const DEFAULT_SESSION: Partial<Session> = {
+  startedAt: undefined,
+  name: undefined,
+  endedAt: undefined,
+};
+
 const ScheduleTemplate = () => {
-  const { register } = useFormContext<FormValues>();
+  const { register, control } = useFormContext<FormValues>();
   const generations = useRecoilValue($generations);
+
+  const { fields, append, remove } = useFieldArray({
+    name: 'sessions',
+    control,
+  });
 
   const generationOptions = useMemo<SelectOption[]>(() => {
     return generations.map(({ generationNumber }) => ({
@@ -53,6 +68,13 @@ const ScheduleTemplate = () => {
       </Styled.ScheduleContent>
       <Styled.SessionContent>
         <Styled.Title>세션 정보</Styled.Title>
+        {fields.map((field, index) => (
+          <SessionTemplate key={field.id} index={index} {...field} onRemove={remove} />
+        ))}
+        <Styled.AddButton type="button" onClick={() => append(DEFAULT_SESSION)}>
+          <Plus />
+          세션 추가
+        </Styled.AddButton>
       </Styled.SessionContent>
     </>
   );

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useRecoilValue } from 'recoil';
+import { DatePickerField, InputField, SelectField } from '@/components';
+import { InputSize } from '@/components/common/Input/Input.component';
+import * as Styled from './ScheduleTemplate.styled';
+import { $generations } from '@/store';
+import { SelectOption } from '@/components/common/Select/Select.component';
+
+interface FormValues {
+  name: string;
+  generationNumber: number;
+  date: string;
+}
+
+const ScheduleTemplate = () => {
+  const { register } = useFormContext<FormValues>();
+  const generations = useRecoilValue($generations);
+
+  const generationOptions = useMemo<SelectOption[]>(() => {
+    return generations.map(({ generationNumber }) => ({
+      label: `${generationNumber}기`,
+      value: generationNumber.toString(),
+    }));
+  }, [generations]);
+
+  return (
+    <>
+      <Styled.ScheduleContent>
+        <Styled.Title>스케줄 정보</Styled.Title>
+        <InputField
+          $size={InputSize.md}
+          label="스케줄 제목"
+          placeholder="내용을 입력해주세요"
+          required
+          {...register('name', { required: true })}
+        />
+        <SelectField
+          label="기수"
+          size="md"
+          options={generationOptions}
+          required
+          isFullWidth
+          {...register('generationNumber', { required: true })}
+        />
+        <DatePickerField
+          label="스케줄 일시"
+          $size="md"
+          placeholder="내용을 입력해주세요"
+          required
+          {...register('date', { required: true })}
+        />
+      </Styled.ScheduleContent>
+      <Styled.SessionContent>
+        <Styled.Title>세션 정보</Styled.Title>
+      </Styled.SessionContent>
+    </>
+  );
+};
+
+export default ScheduleTemplate;

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
@@ -21,6 +21,7 @@ const DEFAULT_SESSION: Partial<Session> = {
   startedAt: undefined,
   name: undefined,
   endedAt: undefined,
+  contentsCreateRequests: [],
 };
 
 const ScheduleTemplate = () => {

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.component.tsx
@@ -8,16 +8,16 @@ import { $generations } from '@/store';
 import { SelectOption } from '@/components/common/Select/Select.component';
 import { SessionTemplate } from '../SessionTemplate';
 import Plus from '@/assets/svg/plus-20.svg';
-import { Session } from '@/types';
+import { EventCreateRequest } from '@/types';
 
 interface FormValues {
   name: string;
   generationNumber: number;
   date: string;
-  sessions: Session[];
+  sessions: EventCreateRequest[];
 }
 
-const DEFAULT_SESSION: Partial<Session> = {
+const DEFAULT_SESSION: Partial<EventCreateRequest> = {
   startedAt: undefined,
   name: undefined,
   endedAt: undefined,

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.styled.ts
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.styled.ts
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ScheduleContent = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    height: 36.9rem;
+    padding: 2.4rem;
+    background-color: ${theme.colors.white};
+    border: 0.1rem solid ${theme.colors.gray30};
+    border-radius: 2rem;
+  `}
+`;
+
+export const Title = styled.h3`
+  ${({ theme }) => css`
+    ${theme.fonts.bold24};
+
+    color: ${theme.colors.gray80};
+  `}
+`;
+
+export const SessionContent = styled.div`
+  ${({ theme }) => css`
+    margin-top: 2.4rem;
+    padding: 3.2rem;
+    background-color: ${theme.colors.white};
+    border: 0.1rem solid ${theme.colors.gray30};
+    border-radius: 2rem;
+  `}
+`;

--- a/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.styled.ts
+++ b/src/components/Schedule/ScheduleTemplate/ScheduleTemplate.styled.ts
@@ -31,3 +31,12 @@ export const SessionContent = styled.div`
     border-radius: 2rem;
   `}
 `;
+
+export const AddButton = styled.button`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin: 0 auto;
+  margin-top: 2.4rem;
+  background-color: transparent;
+`;

--- a/src/components/Schedule/ScheduleTemplate/index.ts
+++ b/src/components/Schedule/ScheduleTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as ScheduleTemplate } from './ScheduleTemplate.component';

--- a/src/components/Schedule/SessionTemplate/SessionTemplate.component.tsx
+++ b/src/components/Schedule/SessionTemplate/SessionTemplate.component.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { InputField } from '@/components';
 import * as Styled from './SessionTemplate.styled';
 import Time from '@/assets/svg/time-16.svg';
-
+import Plus from '@/assets/svg/plus-20.svg';
 import Minus from '@/assets/svg/minus-20.svg';
+import { ContentTemplate } from '../ContentTemplate';
+import { ContentsCreateRequest } from '@/types';
 
 interface SessionTemplateProps {
   index: number;
   onRemove: (index: number) => void;
 }
 
+const DEFAULT_CONTENT: Partial<ContentsCreateRequest> = {};
+
 const SessionTemplate = ({ index, onRemove }: SessionTemplateProps) => {
-  const { register } = useFormContext();
+  const { register, control } = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: `sessions.${index}.contentsCreateRequests`,
+    control,
+  });
 
   const handleRemoveSession = () => {
     onRemove(index);
@@ -45,6 +54,21 @@ const SessionTemplate = ({ index, onRemove }: SessionTemplateProps) => {
           {...register(`sessions.${index}.endedAt`)}
         />
       </Styled.SessionTimeInputWrapper>
+      <Styled.ContentTemplateWrapper>
+        {fields.map((field, fieldIndex) => (
+          <ContentTemplate
+            name={`sessions.${index}.contentsCreateRequests`}
+            key={field.id}
+            index={fieldIndex}
+            onRemove={remove}
+          />
+        ))}
+        <Styled.AddButton onClick={() => append(DEFAULT_CONTENT)}>
+          <Plus />
+          콘텐츠 추가
+        </Styled.AddButton>
+      </Styled.ContentTemplateWrapper>
+
       <Styled.DeleteButton onClick={handleRemoveSession}>
         <Minus />
         세션 삭제

--- a/src/components/Schedule/SessionTemplate/SessionTemplate.component.tsx
+++ b/src/components/Schedule/SessionTemplate/SessionTemplate.component.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { InputField } from '@/components';
+import * as Styled from './SessionTemplate.styled';
+import Time from '@/assets/svg/time-16.svg';
+
+import Minus from '@/assets/svg/minus-20.svg';
+
+interface SessionTemplateProps {
+  index: number;
+  onRemove: (index: number) => void;
+}
+
+const SessionTemplate = ({ index, onRemove }: SessionTemplateProps) => {
+  const { register } = useFormContext();
+
+  const handleRemoveSession = () => {
+    onRemove(index);
+  };
+
+  return (
+    <Styled.SessionTemplateWrapper>
+      <InputField
+        $size="md"
+        label="세션명"
+        placeholder="세션명을 입력해주세요"
+        required
+        {...register(`sessions.${index}.title`)}
+      />
+      <Styled.SessionTimeInputLabel>
+        세션 진행 시간
+        <Styled.RequiredDot />
+      </Styled.SessionTimeInputLabel>
+      <Styled.SessionTimeInputWrapper>
+        <Styled.SessionTimeInput
+          $size="md"
+          endIcon={<Time />}
+          placeholder="13:00"
+          {...register(`sessions.${index}.startedAt`)}
+        />
+        <Styled.SessionTimeInput
+          endIcon={<Time />}
+          $size="md"
+          placeholder="13:45"
+          {...register(`sessions.${index}.endedAt`)}
+        />
+      </Styled.SessionTimeInputWrapper>
+      <Styled.DeleteButton onClick={handleRemoveSession}>
+        <Minus />
+        세션 삭제
+      </Styled.DeleteButton>
+    </Styled.SessionTemplateWrapper>
+  );
+};
+
+export default SessionTemplate;

--- a/src/components/Schedule/SessionTemplate/SessionTemplate.styled.ts
+++ b/src/components/Schedule/SessionTemplate/SessionTemplate.styled.ts
@@ -45,6 +45,25 @@ export const SessionTimeInput = styled(InputField)`
   }
 `;
 
+export const ContentTemplateWrapper = styled.div`
+  ${({ theme }) => css`
+    margin-top: 2.4rem;
+    padding: 1rem;
+    background-color: ${theme.colors.gray20};
+    border-radius: 1.2rem;
+  `}
+`;
+
+export const AddButton = styled.button`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  height: 5.6rem;
+  margin: 0 auto;
+  margin-top: 2.4rem;
+  background-color: transparent;
+`;
+
 export const DeleteButton = styled.button`
   display: flex;
   gap: 0.4rem;

--- a/src/components/Schedule/SessionTemplate/SessionTemplate.styled.ts
+++ b/src/components/Schedule/SessionTemplate/SessionTemplate.styled.ts
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { InputField } from '@/components';
+
+export const SessionTemplateWrapper = styled.div`
+  ${({ theme }) => css`
+    padding: 2rem;
+    background-color: ${theme.colors.gray5};
+    border-radius: 2rem;
+  `}
+`;
+
+export const SessionTimeInputLabel = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.medium15}
+
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    margin: 4.4rem 0 0.6rem;
+    color: ${theme.colors.gray70};
+  `}
+`;
+
+export const RequiredDot = styled.span`
+  ${({ theme }) => css`
+    width: 0.6rem;
+    height: 0.6rem;
+    background-color: ${theme.colors.red50};
+    border-radius: 50%;
+  `}
+`;
+
+export const SessionTimeInputWrapper = styled.div`
+  display: flex;
+  gap: 0.6rem;
+`;
+
+export const SessionTimeInput = styled(InputField)`
+  display: inline-block;
+  flex: 0;
+
+  input {
+    width: 16rem;
+  }
+`;
+
+export const DeleteButton = styled.button`
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  height: 5.6rem;
+  margin: 0 auto;
+  margin-top: 2.4rem;
+  background-color: transparent;
+`;

--- a/src/components/Schedule/SessionTemplate/index.ts
+++ b/src/components/Schedule/SessionTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as SessionTemplate } from './SessionTemplate.component';

--- a/src/components/Schedule/index.ts
+++ b/src/components/Schedule/index.ts
@@ -1,0 +1,1 @@
+export * from './ScheduleTemplate';

--- a/src/components/common/Input/Input.component.tsx
+++ b/src/components/common/Input/Input.component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ReactElement } from 'react';
 import { ValueOf } from '@/types';
 import * as Styled from './Input.styled';
 
@@ -16,6 +16,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   description?: string;
   errorMessage?: string;
   fill?: boolean;
+  endIcon?: ReactElement;
 }
 
 const Input = (
@@ -28,12 +29,14 @@ const Input = (
     required,
     description,
     fill,
+    endIcon,
+    disabled,
     ...resetProps
   }: InputProps,
   ref: React.Ref<HTMLInputElement>,
 ) => {
   return (
-    <Styled.InputWrapper className={className} fill={fill}>
+    <Styled.InputContainer className={className} fill={fill}>
       {label && (
         <Styled.InputLabel htmlFor={id}>
           <span>{label}</span>
@@ -41,9 +44,12 @@ const Input = (
         </Styled.InputLabel>
       )}
       {description && <Styled.Description>{description}</Styled.Description>}
-      <Styled.Input ref={ref} id={id} $size={$size} errorMessage={errorMessage} {...resetProps} />
+      <Styled.InputWrapper $size={$size} errorMessage={errorMessage} disabled={disabled}>
+        <Styled.Input ref={ref} id={id} disabled={disabled} {...resetProps} />
+        {endIcon}
+      </Styled.InputWrapper>
       {errorMessage && <Styled.InputErrorMessage>{errorMessage}</Styled.InputErrorMessage>}
-    </Styled.InputWrapper>
+    </Styled.InputContainer>
   );
 };
 

--- a/src/components/common/Input/Input.component.tsx
+++ b/src/components/common/Input/Input.component.tsx
@@ -44,8 +44,8 @@ const Input = (
         </Styled.InputLabel>
       )}
       {description && <Styled.Description>{description}</Styled.Description>}
-      <Styled.InputWrapper $size={$size} errorMessage={errorMessage} disabled={disabled}>
-        <Styled.Input ref={ref} id={id} disabled={disabled} {...resetProps} />
+      <Styled.InputWrapper errorMessage={errorMessage} disabled={disabled}>
+        <Styled.Input $size={$size} ref={ref} id={id} disabled={disabled} {...resetProps} />
         {endIcon}
       </Styled.InputWrapper>
       {errorMessage && <Styled.InputErrorMessage>{errorMessage}</Styled.InputErrorMessage>}

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -11,9 +11,10 @@ interface StyledInputProps {
   $size: InputSizeType;
   errorMessage?: string;
   fill?: boolean;
+  disabled?: boolean;
 }
 
-export const InputWrapper = styled.div<InputWrapperProps>`
+export const InputContainer = styled.div<InputWrapperProps>`
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -53,31 +54,30 @@ export const Description = styled.span`
   `}
 `;
 
-export const Input = styled.input<StyledInputProps>`
-  ${({ theme, $size, errorMessage }) => css`
+export const InputWrapper = styled.div<StyledInputProps>`
+  ${({ theme, $size, errorMessage, disabled }) => css`
     ${theme.input.size[$size]};
 
-    color: ${theme.colors.gray70};
+    display: flex;
+    align-items: center;
+    background-color: white;
     border: 0.1rem solid ${theme.colors.gray30};
     border-radius: 0.9rem;
-    outline: none;
-
-    &::placeholder {
-      color: ${theme.colors.gray50};
-    }
 
     &:hover {
       border: 0.1rem solid ${theme.colors.purple40};
     }
 
-    &:focus {
+    &:focus-within {
       border: 0.1rem solid ${theme.colors.purple70};
     }
 
-    &:disabled {
-      background-color: ${theme.colors.gray5};
-      border: 0.1rem solid ${theme.colors.gray30};
-    }
+    ${disabled
+      ? css`
+          background-color: ${theme.colors.gray5};
+          border: 0.1rem solid ${theme.colors.gray30};
+        `
+      : ''}
 
     ${errorMessage
       ? css`
@@ -86,6 +86,20 @@ export const Input = styled.input<StyledInputProps>`
           }
         `
       : ''}
+  `}
+`;
+
+export const Input = styled.input`
+  ${({ theme }) => css`
+    width: 100%;
+    color: ${theme.colors.gray70};
+    background-color: transparent;
+    border: none;
+    outline: none;
+
+    &::placeholder {
+      color: ${theme.colors.gray50};
+    }
   `}
 `;
 

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -61,7 +61,7 @@ export const InputWrapper = styled.div<StyledInputWrapperProps>`
   ${({ theme, errorMessage, disabled }) => css`
     display: flex;
     align-items: center;
-    background-color: white;
+    background-color: ${theme.colors.white};
     border: 0.1rem solid ${theme.colors.gray30};
     border-radius: 0.9rem;
 

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -7,11 +7,14 @@ interface InputWrapperProps {
   fill?: boolean;
 }
 
-interface StyledInputProps {
-  $size: InputSizeType;
+interface StyledInputWrapperProps {
   errorMessage?: string;
   fill?: boolean;
   disabled?: boolean;
+}
+
+interface StyledInputProps {
+  $size: InputSizeType;
 }
 
 export const InputContainer = styled.div<InputWrapperProps>`
@@ -54,15 +57,17 @@ export const Description = styled.span`
   `}
 `;
 
-export const InputWrapper = styled.div<StyledInputProps>`
-  ${({ theme, $size, errorMessage, disabled }) => css`
-    ${theme.input.size[$size]};
-
+export const InputWrapper = styled.div<StyledInputWrapperProps>`
+  ${({ theme, errorMessage, disabled }) => css`
     display: flex;
     align-items: center;
     background-color: white;
     border: 0.1rem solid ${theme.colors.gray30};
     border-radius: 0.9rem;
+
+    svg {
+      margin-right: 1.2rem;
+    }
 
     &:hover {
       border: 0.1rem solid ${theme.colors.purple40};
@@ -89,8 +94,10 @@ export const InputWrapper = styled.div<StyledInputProps>`
   `}
 `;
 
-export const Input = styled.input`
-  ${({ theme }) => css`
+export const Input = styled.input<StyledInputProps>`
+  ${({ theme, $size }) => css`
+    ${theme.input.size[$size]};
+
     width: 100%;
     color: ${theme.colors.gray70};
     background-color: transparent;

--- a/src/components/common/Layout/Layout.component.tsx
+++ b/src/components/common/Layout/Layout.component.tsx
@@ -10,7 +10,7 @@ const Layout = () => {
 
   const isBackgroundGray = useMemo(
     () =>
-      ['login', 'application/', 'application-form/', 'activity-score/'].some((each) =>
+      ['login', 'application/', 'application-form/', 'activity-score/', 'schedule/'].some((each) =>
         pathname.includes(each),
       ),
     [pathname],

--- a/src/components/common/Select/Select.component.tsx
+++ b/src/components/common/Select/Select.component.tsx
@@ -24,6 +24,8 @@ export const SelectPosition = {
 export interface SelectProps {
   className?: string;
   size: ValueOf<typeof SelectSize>;
+  label?: string;
+  required?: boolean;
   position?: ValueOf<typeof SelectPosition>;
   placeholder?: string;
   options: SelectOption[];
@@ -38,6 +40,8 @@ const Select = (
   {
     className,
     size,
+    label,
+    required = false,
     position = SelectPosition.bottom,
     placeholder = '전체',
     options,
@@ -86,6 +90,12 @@ const Select = (
 
   return (
     <div ref={outerRef}>
+      {label && (
+        <Styled.SelectLabel>
+          <span>{label}</span>
+          {required && <Styled.RequiredDot />}
+        </Styled.SelectLabel>
+      )}
       <Styled.SelectContainer className={className} isFullWidth={isFullWidth}>
         <Styled.Select
           size={size}

--- a/src/components/common/Select/Select.styled.ts
+++ b/src/components/common/Select/Select.styled.ts
@@ -49,6 +49,24 @@ const getSelectStyle = (
   }
 };
 
+export const SelectLabel = styled.label`
+  ${({ theme }) => css`
+    ${theme.fonts.medium15}
+    display: flex;
+    margin-bottom: 0.6rem;
+    color: ${theme.colors.gray70};
+  `}
+`;
+
+export const RequiredDot = styled.span`
+  width: 0.6rem;
+  min-width: 0.6rem;
+  height: 0.6rem;
+  margin: 0.8rem 0 0 0.6rem;
+  background-color: #eb6963;
+  border-radius: 50%;
+`;
+
 export const SelectContainer = styled.div<StyledSelectContainerProps>`
   ${({ isFullWidth }) => css`
     position: relative;

--- a/src/components/fields/SelectField/SelectField.component.tsx
+++ b/src/components/fields/SelectField/SelectField.component.tsx
@@ -1,9 +1,27 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
+import { Control, Controller, UseControllerProps } from 'react-hook-form';
 import { Select } from '@/components';
 import { SelectProps } from '@/components/common/Select/Select.component';
 
-const SelectField = (props: SelectProps, ref: React.ForwardedRef<HTMLSelectElement>) => {
-  return <Select {...props} ref={ref} />;
+type SelectFieldProps = {
+  control?: Control<any>;
+} & SelectProps &
+  Omit<UseControllerProps, 'control'>;
+
+const SelectField = ({ name, control, ...restProps }: SelectFieldProps) => {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field: { onChange, ...fieldRestProps } }) => (
+        <Select
+          {...restProps}
+          onChangeOption={(option) => onChange(option.value)}
+          {...fieldRestProps}
+        />
+      )}
+    />
+  );
 };
 
-export default forwardRef<HTMLSelectElement, SelectProps>(SelectField);
+export default SelectField;

--- a/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
+++ b/src/components/modal/ChangeResultModalDialog/ChangeResultModalDialog.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import { useRecoilCallback } from 'recoil';
 import { useForm } from 'react-hook-form';
 import { request } from '@/utils';
-import { ModalWrapper, SelectField, TitleWithContent } from '@/components';
+import { ModalWrapper, Select, TitleWithContent } from '@/components';
 import * as Styled from './ChangeResultModalDialog.styled';
 import * as api from '@/api';
 import { $applicationById, $modalByStorage, ModalKey } from '@/store';
@@ -135,7 +135,7 @@ const ChangeResultModalDialog = ({
         </Styled.SelectedResultArea>
         <Styled.Divider> </Styled.Divider>
         <TitleWithContent title="변경할 합격여부 상태" isActive>
-          <SelectField
+          <Select
             size={SelectSize.md}
             options={applicationResultOptions}
             isFullWidth

--- a/src/pages/CreateSchedule/CreateSchedule.page.tsx
+++ b/src/pages/CreateSchedule/CreateSchedule.page.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { BackButton } from '@/components';
+import * as Styled from './CreateSchedule.styled';
+import { useHistory } from '@/hooks';
+import { PATH } from '@/constants';
+import { ScheduleTemplate } from '@/components/Schedule';
+
+const CreateSchedule = () => {
+  const { handleGoBack } = useHistory();
+
+  const methods = useForm({});
+
+  return (
+    <FormProvider {...methods}>
+      <Styled.CreateSchedulePage>
+        <BackButton label="목록 돌아가기" onClick={() => handleGoBack(PATH.SCHEDULE)} />
+        <Styled.Headline>스케줄</Styled.Headline>
+        <ScheduleTemplate />
+      </Styled.CreateSchedulePage>
+    </FormProvider>
+  );
+};
+
+export default CreateSchedule;

--- a/src/pages/CreateSchedule/CreateSchedule.styled.ts
+++ b/src/pages/CreateSchedule/CreateSchedule.styled.ts
@@ -1,0 +1,16 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const CreateSchedulePage = styled.div`
+  padding: 2rem 0;
+`;
+
+export const Headline = styled.h2`
+  ${({ theme }) => css`
+    margin: 1.4rem 0 2.6rem;
+    color: ${theme.colors.gray80};
+    font-weight: 700;
+    font-size: 3.6rem;
+    line-height: 4.5rem;
+  `}
+`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,3 +10,4 @@ export { default as ErrorPage } from './ErrorPage/ErrorPage.page';
 export { default as ActivityScoreList } from './ActivityScoreList/ActivityScoreList.page';
 export { default as ActivityScoreDetail } from './ActivityScoreDetail/ActivityScoreDetail.page';
 export { default as ScheduleList } from './ScheduleList/ScheduleList.page';
+export { default as CreateSchedule } from './CreateSchedule/CreateSchedule.page';

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -7,3 +7,4 @@ export * from './email';
 export * from './generation';
 export * from './member';
 export * from './scoreHistory';
+export * from './schedule';

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -12,6 +12,21 @@ export interface ScheduleRequest {
   sort?: string;
 }
 
+// MEMO(@mango906): 서버는 세션에 대해 Event라는 이름을 가지고 있으므로 Event 대신 Session
+export interface Session {
+  endedAt: string;
+  name: string;
+  startedAt: string;
+}
+
+export interface CreateScheduleRequest {
+  generationNumber?: number;
+  endedAt: string;
+  name: string;
+  startedAt: string;
+  eventsCreateRequests: Session;
+}
+
 export interface ScheduleResponse {
   endedAt: string;
   generationNumber: number;

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -17,6 +17,13 @@ export interface Session {
   endedAt: string;
   name: string;
   startedAt: string;
+  contentsCreateRequests: ContentsCreateRequest[];
+}
+
+export interface ContentsCreateRequest {
+  title: string;
+  startedAt: string;
+  desc: string;
 }
 
 export interface CreateScheduleRequest {

--- a/src/types/dto/schedule.ts
+++ b/src/types/dto/schedule.ts
@@ -12,8 +12,7 @@ export interface ScheduleRequest {
   sort?: string;
 }
 
-// MEMO(@mango906): 서버는 세션에 대해 Event라는 이름을 가지고 있으므로 Event 대신 Session
-export interface Session {
+export interface EventCreateRequest {
   endedAt: string;
   name: string;
   startedAt: string;
@@ -31,7 +30,7 @@ export interface CreateScheduleRequest {
   endedAt: string;
   name: string;
   startedAt: string;
-  eventsCreateRequests: Session;
+  eventsCreateRequests: EventCreateRequest;
 }
 
 export interface ScheduleResponse {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,1 @@
+export const getReadableIndex = (index: number) => index + 1;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './date';
 export * from './request';
 export * from './string';
 export * from './number';
+export * from './format';


### PR DESCRIPTION
## 변경사항

- SelectField 컴포넌트에 onChagne 옵션 추가해서 react-hook-form 사용할 수 있또록 추가
- Input endIcon 옵션 추가
  - 이떄문에 기존에 input, icon을 감쌀 wrapper가 필요해졌고 에러, disabled, hover, focus 등 액션이 해당 DOM요소로 옮겨졌습니다.
- react-hook-form을 통해 스케쥴 등록 ui 추가
  - ScheduleTemplate > SessionTemplate > ContentTemplate 순으로 호출합니다.
  - 자세한 내용은 api swagger를 참고해보시면 확인하실 수 있습니다.

![localhost_5050_schedule_create (1)](https://user-images.githubusercontent.com/38802280/214027720-1c58a591-f44b-406b-9272-587b7b3e5e42.png)


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)