### PR TITLE
뒤로가기 했을 때 페이징 정보 유지되지 않는 버그 수정

### DIFF
--- a/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
+++ b/src/components/Generation/GenerationSelect/GenerationSelect.component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
+import { useSearchParams } from 'react-router-dom';
 import { Select } from '@/components/common';
 
 import { SelectOption, SelectSize } from '@/components/common/Select/Select.component';
@@ -9,6 +10,7 @@ import { $generationNumber, $generations } from '@/store';
 const GenerationSelect = () => {
   const generations = useRecoilValue($generations);
   const [generationNumber, setGenerationNumber] = useRecoilState($generationNumber);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const options: SelectOption[] = generations.map((generation) => ({
     label: `${generation.generationNumber}기`,
@@ -17,6 +19,8 @@ const GenerationSelect = () => {
 
   const handleChangeGeneration = (selectedOption: SelectOption) => {
     setGenerationNumber(parseInt(selectedOption.value, 10));
+    searchParams.delete('page');
+    setSearchParams(searchParams);
   };
 
   useEffect(() => {

--- a/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
+++ b/src/pages/ApplicationFormList/ApplicationFormList.page.tsx
@@ -166,12 +166,6 @@ const ApplicationFormList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
-  useEffect(() => {
-    searchParams.delete('page');
-    setSearchParams(searchParams);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [generationNumber]);
-
   useLayoutEffect(() => {
     if (isDirty && !isLoading) {
       window.scrollTo({ top: 179, left: 0, behavior: 'smooth' });

--- a/src/pages/ApplicationList/ApplicationList.page.tsx
+++ b/src/pages/ApplicationList/ApplicationList.page.tsx
@@ -299,12 +299,6 @@ const ApplicationList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamName]);
 
-  useEffect(() => {
-    searchParams.delete('page');
-    setSearchParams(searchParams);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [generationNumber]);
-
   useLayoutEffect(() => {
     if (isDirty && !isLoading) {
       window.scrollTo({ top: 179, left: 0, behavior: 'smooth' });


### PR DESCRIPTION
## 변경사항
 
- 지원서에 기수 정보 추가하면서 기수 정보 변경될 떄 page 정보 초기화 하는 로직이 들어갔는데 요게 렌더링떄 한번 실행되어서 뒤로가기 할 떄 마다 실행되므로 기수 선택 모달에서 변경할 때 초기화 하도록 수정하였습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->


- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)