### PR TITLE
스케줄 배포, 배포 취소 가능하게 추가

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -26,3 +26,9 @@ export const updateSchedule = (
   scheduleId: string,
   data: ScheduleUpdateRequest,
 ): Promise<BaseResponse<ScheduleResponse>> => http.put({ url: `/schedules/${scheduleId}`, data });
+
+export const publishSchedule = (scheduleId: string): Promise<BaseResponse<{}>> =>
+  http.post({ url: `/schedules/${scheduleId}/publish` });
+
+export const hideSchedule = (scheduleId: string): Promise<BaseResponse<{}>> =>
+  http.post({ url: `/schedules/${scheduleId}/hide` });

--- a/src/pages/ScheduleDetail/ScheduleDetail.page.tsx
+++ b/src/pages/ScheduleDetail/ScheduleDetail.page.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { BackButton, Button } from '@/components';
 import * as Styled from './ScheduleDetail.styled';
-import { $scheduleDetail } from '@/store';
+import { $modalByStorage, $scheduleDetail, ModalKey } from '@/store';
 import { ScheduleInfoList, SessionListItem } from '@/components/ScheduleDetail';
-import { useHistory } from '@/hooks';
+import { useHistory, useRefreshSelectorFamilyByKey, useToast } from '@/hooks';
 import { getScheduleUpdatePage, PATH } from '@/constants';
+import { ScheduleStatus } from '@/types/dto/schedule';
+import { request } from '@/utils';
+
+import * as api from '@/api';
+import { ToastType } from '@/styles';
 
 const ScheduleDetail = () => {
   const { scheduleId = '' } = useParams();
 
   const { handleGoBack } = useHistory();
   const navigate = useNavigate();
+  const { handleAddToast } = useToast();
+  const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
 
   const {
     name,
@@ -24,24 +31,70 @@ const ScheduleDetail = () => {
     eventList: sessionList,
   } = useRecoilValue($scheduleDetail({ scheduleId: scheduleId ?? '' }));
 
+  const isPublished = status === ScheduleStatus.PUBLIC;
+
+  const handlePublishOrHideSchedule = useRecoilCallback(({ set, refresh }) => async () => {
+    const heading = isPublished ? '스케줄을 배포 취소하시겠습니까?' : '스케줄을 배포하시겠습니까?';
+    const toastMessage = isPublished
+      ? '성공적으로 스케줄의 배포를 취소했습니다'
+      : '성공적으로 스케줄을 배포하였습니다.';
+
+    set($modalByStorage(ModalKey.alertModalDialog), {
+      key: ModalKey.alertModalDialog,
+      isOpen: true,
+      props: {
+        heading,
+        confirmButtonLabel: '확인',
+        handleClickConfirmButton: () => {
+          request({
+            requestFunc: () => {
+              if (isPublished) {
+                return api.hideSchedule(scheduleId);
+              }
+
+              return api.publishSchedule(scheduleId);
+            },
+            errorHandler: handleAddToast,
+            onSuccess: () => {
+              handleAddToast({
+                type: ToastType.success,
+                message: toastMessage,
+              });
+
+              refresh($scheduleDetail({ scheduleId: scheduleId ?? '' }));
+              refreshSelectorFamilyByKey('schedules');
+            },
+            onCompleted: () => {
+              set($modalByStorage(ModalKey.alertModalDialog), {
+                key: ModalKey.alertModalDialog,
+                isOpen: false,
+              });
+            },
+          });
+        },
+      },
+    });
+  });
+
   return (
     <Styled.ScheduleDetailPage>
       <BackButton onClick={() => handleGoBack(PATH.SCHEDULE)} />
       <Styled.Header>
         <h2>스케줄 상세</h2>
         <Styled.ButtonWrapper>
-          <Button $size="sm" shape="defaultLine">
+          <Button $size="sm" shape="defaultLine" disabled={isPublished}>
             삭제
           </Button>
           <Button
             $size="sm"
             shape="primaryLine"
             onClick={() => navigate(getScheduleUpdatePage(scheduleId))}
+            disabled={isPublished}
           >
             수정
           </Button>
-          <Button $size="sm" shape="primary">
-            배포
+          <Button $size="sm" shape="primary" onClick={handlePublishOrHideSchedule}>
+            {isPublished ? '배포 취소' : '배포'}
           </Button>
         </Styled.ButtonWrapper>
       </Styled.Header>

--- a/src/pages/UpdateSchedule/UpdateSchedule.page.tsx
+++ b/src/pages/UpdateSchedule/UpdateSchedule.page.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { $modalByStorage, $scheduleDetail, ModalKey } from '@/store';
@@ -17,6 +17,7 @@ import {
 } from '@/utils';
 
 import { ToastType } from '@/styles';
+import { ScheduleStatus } from '@/types';
 
 const UpdateSchedule = () => {
   const { scheduleId } = useParams();
@@ -31,6 +32,8 @@ const UpdateSchedule = () => {
   const { handleGoBack } = useHistory();
   const { handleAddToast } = useToast();
   const refreshSelectorFamilyByKey = useRefreshSelectorFamilyByKey();
+
+  const isPublished = scheduleResponse.status === ScheduleStatus.PUBLIC;
 
   const methods = useForm<ScheduleFormValues>({ defaultValues: defaultFormValues });
 
@@ -104,6 +107,12 @@ const UpdateSchedule = () => {
         });
       },
   );
+
+  if (isPublished) {
+    handleAddToast({ type: 'error', message: '배포가 되어 있는 스케줄은 수정할 수 없습니다.' });
+
+    return <Navigate to={getScheduleDetailPage(scheduleId ?? '')} replace />;
+  }
 
   return (
     <>

--- a/src/styles/themes/button.ts
+++ b/src/styles/themes/button.ts
@@ -100,7 +100,7 @@ export const button = {
 
       &:disabled {
         color: ${colors.purple40};
-        background-color: ${colors.purple40};
+        background-color: ${colors.purple10};
         border-color: ${colors.purple20};
       }
 


### PR DESCRIPTION
## 변경사항

- Button 컴포넌트의 primaryLine disabled일 때 스타일이 이상해서 수정
- 스케줄 배포, 배포 취소 가능하게 추가
  - 스케줄이 배포되어있으면 수정, 삭제는 불가능 해야함
  - 스케줄 배포 되어있을 떄 수정 페이지 접근시 에러 토스트와 함꼐 리다이렉트 로직 추가

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 버그 수정

### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
- [ ] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [ ] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [ ] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)