### PR TITLE
헬퍼 생성 시 문자열 변환 로직 이슈 해결

### DIFF
--- a/src/api/adminMember.ts
+++ b/src/api/adminMember.ts
@@ -25,7 +25,7 @@ export const createAdminMember = ({
     url: `/admin-members`,
     data: {
       password,
-      position: `${platform.toLocaleUpperCase()}_HELPER`,
+      position: `${platform}_HELPER`,
       username,
     },
   });

--- a/src/components/modal/CreateHelperAdminMemberDialog/CreateHelperAdminMemberDialog.component.tsx
+++ b/src/components/modal/CreateHelperAdminMemberDialog/CreateHelperAdminMemberDialog.component.tsx
@@ -28,7 +28,9 @@ const CreateHelperAdminMemberDialog = ({ refreshList }: CreateHelperAdminMemberD
 
   const getTeams = async () => {
     const { data } = await api.getTeams();
-    const newOptions = data.map((i) => ({ value: i.name, label: i.name }));
+    const newOptions = data.map(({ name }) => {
+      return { value: name === 'iOS' ? name : name.toLocaleUpperCase(), label: name };
+    });
     setOptions(newOptions);
     setValue('platform', newOptions[0].value);
   };


### PR DESCRIPTION
## 변경사항

- iOS, Web, Android ... 형태의 문자열에 대해 `String.prototype.toLocaleUpperCase()`를 적용한 결과를 `"${platform}_ HELPER"`로 변환 후 요청에 전달하면서, 서버 에러가 발생하여 iOS 팀에 대해서만 원본 문자열을 그대로 전달하도록 대응합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
- [x] [코딩컨벤션](https://github.com/mash-up-kr/mash-up-recruit-fe/wiki/Coding-Convention)을 준수하였는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가? (개발에 필요하여 고의적으로 남겨둔것 제외)